### PR TITLE
fix(cross-transfer): disable the multichain app

### DIFF
--- a/apps/swap/components/CrossTransfer/config/index.ts
+++ b/apps/swap/components/CrossTransfer/config/index.ts
@@ -88,10 +88,10 @@ export const CROSS_TRANSFER_CONFIG: Record<string, Record<string, Record<string,
     },
     [Chains.Moonbeam]: {
       [Chains.Astar]: [Apps.cBridgeApp],
-      [Chains.Moonriver]: [Apps.MultichainApp],
+      // [Chains.Moonriver]: [Apps.MultichainApp],
     },
     [Chains.Moonriver]: {
-      [Chains.Moonbeam]: [Apps.MultichainApp],
+      // [Chains.Moonbeam]: [Apps.MultichainApp],
       [Chains.BifrostKusama]: [Apps.SubBridgeDapp],
     },
     [Chains.BifrostKusama]: {


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on commenting out two lines of code that were causing issues with app functionality. 

### Detailed summary
- Commented out `[Chains.Moonriver]: [Apps.MultichainApp]` in `[Chains.Moonbeam]` and `[Chains.Moonbeam]: [Apps.MultichainApp]` in `[Chains.Moonriver]`
- Added `[Chains.Astar]: [Apps.cBridgeApp]` in `[Chains.Moonbeam]`
- Added `[Chains.BifrostKusama]: [Apps.SubBridgeDapp]` in `[Chains.Moonriver]`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->