### PR TITLE
fix(nova-wallet): use `getConnectorName` instead of `connector.name`

### DIFF
--- a/packages/wagmi/components/Wallet/Button.tsx
+++ b/packages/wagmi/components/Wallet/Button.tsx
@@ -27,7 +27,7 @@ const Icons: Record<string, ReactNode> = {
   'SubWallet': <SubwalletIcon width={16} height={16} />,
   'WalletConnect': <WalletConnectIcon width={16} height={16} />,
   'Coinbase Wallet': <CoinbaseWalletIcon width={16} height={16} />,
-  'Safe': <GnosisSafeIcon width={16} height={16} />,
+  'Gnosis Safe': <GnosisSafeIcon width={16} height={16} />,
   'Ledger': <LedgerIcon width={16} height={16} />,
   'ImToken': <ImTokenIcon width={16} height={16} />,
   'Nova Wallet': <NovaWalletIcon width={16} height={16} />,
@@ -40,15 +40,18 @@ export type Props<C extends React.ElementType> = ButtonProps<C> & {
 }
 
 function getInjectedName(connector: Connector): string {
+  if (typeof window !== 'undefined') {
+    if ((window.ethereum as any)?.isNovaWallet)
+      return 'Nova Wallet'
+    return connector.name
+  }
+  return connector.name
+}
+
+function getConnectorName(connector: Connector): string {
   switch (connector.name) {
-    case 'Injected': {
-      if (typeof window !== 'undefined') {
-        if ((window.ethereum as any)?.isNovaWallet)
-          return 'Nova Wallet'
-        return connector.name
-      }
-      return connector.name
-    }
+    case 'Injected':
+      return getInjectedName(connector)
     case 'Safe':
       return 'Gnosis Safe'
     default:
@@ -111,9 +114,9 @@ export const Button = <C extends React.ElementType>({
                         className="flex items-center gap-3 group"
                       >
                         <div className="-ml-[6px] group-hover:bg-blue-100 rounded-full group-hover:ring-[5px] group-hover:ring-blue-100">
-                          {Icons[getInjectedName(connector)] && Icons[getInjectedName(connector)]}
+                          {Icons[getConnectorName(connector)] && Icons[getConnectorName(connector)]}
                         </div>{' '}
-                        {getInjectedName(connector)}
+                        {getConnectorName(connector)}
                       </Menu.Item>
                     ))}
                 </div>

--- a/packages/wagmi/components/Wallet/Button.tsx
+++ b/packages/wagmi/components/Wallet/Button.tsx
@@ -16,8 +16,8 @@ import {
 } from '@zenlink-interface/ui'
 import type { ReactNode } from 'react'
 import React, { useCallback, useMemo } from 'react'
+import type { Connector } from 'wagmi'
 import { useAccount, useConnect } from 'wagmi'
-
 import { t } from '@lingui/macro'
 
 const Icons: Record<string, ReactNode> = {
@@ -37,6 +37,23 @@ export type Props<C extends React.ElementType> = ButtonProps<C> & {
   // TODO ramin: remove param when wagmi adds onConnecting callback to useAccount
   hack?: ReturnType<typeof useConnect>
   appearOnMount?: boolean
+}
+
+function getInjectedName(connector: Connector): string {
+  switch (connector.name) {
+    case 'Injected': {
+      if (typeof window !== 'undefined') {
+        if ((window.ethereum as any)?.isNovaWallet)
+          return 'Nova Wallet'
+        return connector.name
+      }
+      return connector.name
+    }
+    case 'Safe':
+      return 'Gnosis Safe'
+    default:
+      return connector.name
+  }
 }
 
 export const Button = <C extends React.ElementType>({
@@ -94,9 +111,9 @@ export const Button = <C extends React.ElementType>({
                         className="flex items-center gap-3 group"
                       >
                         <div className="-ml-[6px] group-hover:bg-blue-100 rounded-full group-hover:ring-[5px] group-hover:ring-blue-100">
-                          {Icons[connector.name] && Icons[connector.name]}
+                          {Icons[getInjectedName(connector)] && Icons[getInjectedName(connector)]}
                         </div>{' '}
-                        {connector.name === 'Safe' ? 'Gnosis Safe' : connector.name}
+                        {getInjectedName(connector)}
                       </Menu.Item>
                     ))}
                 </div>


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR changes the names of some wallet connectors displayed in the UI and adds a function to handle injected wallets. 

### Detailed summary
- Renames the 'Safe' wallet connector to 'Gnosis Safe'
- Adds a function to handle injected wallets and display their name as 'Nova Wallet' if detected
- Uses the new function to display the correct connector name in the UI

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->