### PR TITLE
chore(i18n): new GPT translation updates

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zenlink-interface",
   "version": "0.0.0",
-  "packageManager": "pnpm@8.4.0",
+  "packageManager": "pnpm@8.6.2",
   "license": "LGPL-2.1-or-later",
   "repository": "https://github.com/zenlinkpro/zenlink-interface.git",
   "engines": {
@@ -16,11 +16,11 @@
     "build-packages": "turbo run build --filter={./packages/**}...",
     "build": "turbo run build --filter=[HEAD^1]",
     "build:ci": "turbo run build --filter=[HEAD^1]",
-    "dev": "turbo run dev --no-cache --concurrency 50 --parallel --continue",
+    "dev": "turbo run dev --no-cache --concurrency=50 --parallel --continue",
     "generate": "turbo run generate",
     "generate:ci": "turbo run generate --filter=[HEAD^1]",
     "lint": "turbo run lint --parallel",
-    "lint-packages": "turbo run lint --parallel --filter={./packages/**}[HEAD^1]...",
+    "lint-packages": "turbo run lint --parallel --filter={./packages/**}...",
     "lint:ci": "turbo run lint --parallel --filter=[HEAD^1]",
     "clean": "turbo run clean && rm -rf node_modules",
     "test-apps": "turbo run test --filter={./apps/*}[HEAD^1]...",

--- a/packages/config/router/src/index.ts
+++ b/packages/config/router/src/index.ts
@@ -1,6 +1,6 @@
 import { ParachainId } from '@zenlink-interface/chain'
 import type { Type } from '@zenlink-interface/currency'
-import { DAI, DOT, FRAX, Native, Token, USDC, USDT, WBTC, WNATIVE } from '@zenlink-interface/currency'
+import { ARB, DAI, DOT, FRAX, Native, Token, USDC, USDT, WBTC, WNATIVE } from '@zenlink-interface/currency'
 
 export const BASES_TO_CHECK_TRADES_AGAINST: { readonly [chainId: number]: Token[] } = {
   [ParachainId.ASTAR]: [
@@ -50,12 +50,13 @@ export const BASES_TO_CHECK_TRADES_AGAINST: { readonly [chainId: number]: Token[
     USDC[ParachainId.ARBITRUM_ONE],
     USDT[ParachainId.ARBITRUM_ONE],
     FRAX[ParachainId.ARBITRUM_ONE],
+    ARB[ParachainId.ARBITRUM_ONE],
     new Token({
       chainId: ParachainId.ARBITRUM_ONE,
-      address: '0xaf88d065e77c8cC2239327C5EDb3A432268e5831',
+      address: '0xFF970A61A04b1cA14834A43f5dE4533eBDDB5CC8',
       decimals: 6,
-      name: 'USD Coin',
-      symbol: 'USDC',
+      name: 'USD Coin (Arb1)',
+      symbol: 'USDC.e',
     }),
   ],
 }
@@ -81,13 +82,7 @@ export const COMMON_BASES: { readonly [chainId: number]: Type[] } = {
   ],
   [ParachainId.ARBITRUM_ONE]: [
     Native.onChain(ParachainId.ARBITRUM_ONE),
-    new Token({
-      chainId: ParachainId.ARBITRUM_ONE,
-      address: '0xaf88d065e77c8cC2239327C5EDb3A432268e5831',
-      decimals: 6,
-      name: 'USD Coin',
-      symbol: 'USDC',
-    }),
+    ARB[ParachainId.ARBITRUM_ONE],
     USDC[ParachainId.ARBITRUM_ONE],
     USDT[ParachainId.ARBITRUM_ONE],
     DAI[ParachainId.ARBITRUM_ONE],

--- a/packages/currency/src/constants/tokenAddresses.ts
+++ b/packages/currency/src/constants/tokenAddresses.ts
@@ -33,6 +33,7 @@ export const USDC_ADDRESS: Record<number | string, string> = {
   [ParachainId.MOONRIVER]: '0xE3F5a90F9cb311505cd691a46596599aA1A0AD7D',
   [ParachainId.MOONBEAM]: '0x818ec0A7Fe18Ff94269904fCED6AE3DaE6d6dC0b',
   [ParachainId.ASTAR]: '0x6a2d262D56735DbA19Dd70682B39F6bE9a931D98',
+  [ParachainId.ARBITRUM_ONE]: '0xaf88d065e77c8cC2239327C5EDb3A432268e5831',
 }
 
 export const USDT_ADDRESS: Record<number | string, string> = {
@@ -71,4 +72,8 @@ export const DOT_ADDRESS: Record<number | string, string> = {
 
 export const LINK_ADDRESS: Record<number | string, string> = {
   [ParachainId.ARBITRUM_ONE]: '0xf97f4df75117a78c1A5a0DBb814Af92458539FB4',
+}
+
+export const ARB_ADDRESS: Record<number | string, string> = {
+  [ParachainId.ARBITRUM_ONE]: '0x912CE59144191C1204E64559FE8253a0e49E6548',
 }

--- a/packages/currency/src/constants/tokens.ts
+++ b/packages/currency/src/constants/tokens.ts
@@ -2,6 +2,7 @@ import { ParachainId } from '@zenlink-interface/chain'
 import { Token } from '../Token'
 import { addressMapToTokenMap } from '../addressMapToTokenMap'
 import {
+  ARB_ADDRESS,
   DAI_ADDRESS,
   DOT_ADDRESS,
   FRAX_ADDRESS,
@@ -109,13 +110,6 @@ export const USDC = {
     },
     USDC_ADDRESS,
   ),
-  [ParachainId.ARBITRUM_ONE]: new Token({
-    chainId: ParachainId.ARBITRUM_ONE,
-    address: '0xFF970A61A04b1cA14834A43f5dE4533eBDDB5CC8',
-    decimals: 6,
-    symbol: 'USDC.e',
-    name: 'USD Coin (Arb1)',
-  }),
 } as { [k: string]: Token }
 
 export const USDT = addressMapToTokenMap(
@@ -179,4 +173,13 @@ export const LINK = addressMapToTokenMap(
     name: 'ChainLink Token',
   },
   LINK_ADDRESS,
+) as Record<keyof typeof LINK_ADDRESS, Token>
+
+export const ARB = addressMapToTokenMap(
+  {
+    decimals: 18,
+    symbol: 'ARB',
+    name: 'Arbitrum',
+  },
+  ARB_ADDRESS,
 ) as Record<keyof typeof LINK_ADDRESS, Token>

--- a/packages/locales/af-ZA.po
+++ b/packages/locales/af-ZA.po
@@ -410,7 +410,7 @@ msgstr "Handel"
 
 #: apps/swap/components/Route.tsx
 msgid "Optimized route"
-msgstr ""
+msgstr "Geoptimeerde roete"
 
 #: apps/swap/components/CrossTransfer/TokenSelector/TokenSelectorDialog.tsx
 #: packages/compat/components/TokenSelector/TokenSelectorDialog.tsx
@@ -786,7 +786,7 @@ msgstr "Lig Them"
 
 #: apps/pool/components/PoolsSection/Tables/TableFilters/TableFilters.tsx
 msgid "Farms"
-msgstr ""
+msgstr "Plase"
 
 #: packages/wagmi/hooks/referrals/useSetCodeReview.ts
 msgid "Setting referral code ({code})"
@@ -1170,10 +1170,6 @@ msgstr "Beste Beloning APR:"
 #: packages/wagmi/components/NotificationCentre/NotificationCentre.tsx
 msgid "Clear"
 msgstr "Maak skoon"
-
-#: packages/wagmi/components/Wallet/Button.tsx
-#~ msgid "Authorize Wallet"
-#~ msgstr "Magtig sak"
 
 #: apps/pool/components/RemoveSection/RemoveSectionStable.tsx
 #: apps/pool/components/RemoveSection/RemoveSectionStandard.tsx

--- a/packages/locales/fr-FR.po
+++ b/packages/locales/fr-FR.po
@@ -410,7 +410,7 @@ msgstr "Échange"
 
 #: apps/swap/components/Route.tsx
 msgid "Optimized route"
-msgstr ""
+msgstr "Route optimisée"
 
 #: apps/swap/components/CrossTransfer/TokenSelector/TokenSelectorDialog.tsx
 #: packages/compat/components/TokenSelector/TokenSelectorDialog.tsx
@@ -786,7 +786,7 @@ msgstr "Thème clair"
 
 #: apps/pool/components/PoolsSection/Tables/TableFilters/TableFilters.tsx
 msgid "Farms"
-msgstr ""
+msgstr "Fermes"
 
 #: packages/wagmi/hooks/referrals/useSetCodeReview.ts
 msgid "Setting referral code ({code})"
@@ -1170,10 +1170,6 @@ msgstr "Meilleur taux APR :"
 #: packages/wagmi/components/NotificationCentre/NotificationCentre.tsx
 msgid "Clear"
 msgstr "Effacer"
-
-#: packages/wagmi/components/Wallet/Button.tsx
-#~ msgid "Authorize Wallet"
-#~ msgstr "Autoriser le portefeuille"
 
 #: apps/pool/components/RemoveSection/RemoveSectionStable.tsx
 #: apps/pool/components/RemoveSection/RemoveSectionStandard.tsx

--- a/packages/locales/ja-JP.po
+++ b/packages/locales/ja-JP.po
@@ -410,7 +410,7 @@ msgstr "取引"
 
 #: apps/swap/components/Route.tsx
 msgid "Optimized route"
-msgstr ""
+msgstr "最適化されたルート"
 
 #: apps/swap/components/CrossTransfer/TokenSelector/TokenSelectorDialog.tsx
 #: packages/compat/components/TokenSelector/TokenSelectorDialog.tsx
@@ -786,7 +786,7 @@ msgstr "ライトテーマ"
 
 #: apps/pool/components/PoolsSection/Tables/TableFilters/TableFilters.tsx
 msgid "Farms"
-msgstr ""
+msgstr "農場"
 
 #: packages/wagmi/hooks/referrals/useSetCodeReview.ts
 msgid "Setting referral code ({code})"
@@ -1170,10 +1170,6 @@ msgstr "最高報酬年利率："
 #: packages/wagmi/components/NotificationCentre/NotificationCentre.tsx
 msgid "Clear"
 msgstr "クリア"
-
-#: packages/wagmi/components/Wallet/Button.tsx
-#~ msgid "Authorize Wallet"
-#~ msgstr "ウォレットを承認する"
 
 #: apps/pool/components/RemoveSection/RemoveSectionStable.tsx
 #: apps/pool/components/RemoveSection/RemoveSectionStandard.tsx

--- a/packages/locales/ko-KR.po
+++ b/packages/locales/ko-KR.po
@@ -410,7 +410,7 @@ msgstr "거래"
 
 #: apps/swap/components/Route.tsx
 msgid "Optimized route"
-msgstr ""
+msgstr "최적화된 경로"
 
 #: apps/swap/components/CrossTransfer/TokenSelector/TokenSelectorDialog.tsx
 #: packages/compat/components/TokenSelector/TokenSelectorDialog.tsx
@@ -786,7 +786,7 @@ msgstr "밝은 테마"
 
 #: apps/pool/components/PoolsSection/Tables/TableFilters/TableFilters.tsx
 msgid "Farms"
-msgstr ""
+msgstr "농장"
 
 #: packages/wagmi/hooks/referrals/useSetCodeReview.ts
 msgid "Setting referral code ({code})"
@@ -1170,10 +1170,6 @@ msgstr "최고 보상 APR:"
 #: packages/wagmi/components/NotificationCentre/NotificationCentre.tsx
 msgid "Clear"
 msgstr "지우기"
-
-#: packages/wagmi/components/Wallet/Button.tsx
-#~ msgid "Authorize Wallet"
-#~ msgstr "지갑 인증하기"
 
 #: apps/pool/components/RemoveSection/RemoveSectionStable.tsx
 #: apps/pool/components/RemoveSection/RemoveSectionStandard.tsx

--- a/packages/locales/ru-RU.po
+++ b/packages/locales/ru-RU.po
@@ -410,7 +410,7 @@ msgstr "Торговать"
 
 #: apps/swap/components/Route.tsx
 msgid "Optimized route"
-msgstr ""
+msgstr "Оптимизированный маршрут"
 
 #: apps/swap/components/CrossTransfer/TokenSelector/TokenSelectorDialog.tsx
 #: packages/compat/components/TokenSelector/TokenSelectorDialog.tsx
@@ -786,7 +786,7 @@ msgstr "Светлая тема"
 
 #: apps/pool/components/PoolsSection/Tables/TableFilters/TableFilters.tsx
 msgid "Farms"
-msgstr ""
+msgstr "Фермы"
 
 #: packages/wagmi/hooks/referrals/useSetCodeReview.ts
 msgid "Setting referral code ({code})"
@@ -1170,10 +1170,6 @@ msgstr "Лучший годовой процент вознаграждения:
 #: packages/wagmi/components/NotificationCentre/NotificationCentre.tsx
 msgid "Clear"
 msgstr "Очистить"
-
-#: packages/wagmi/components/Wallet/Button.tsx
-#~ msgid "Authorize Wallet"
-#~ msgstr "Авторизовать кошелек"
 
 #: apps/pool/components/RemoveSection/RemoveSectionStable.tsx
 #: apps/pool/components/RemoveSection/RemoveSectionStandard.tsx

--- a/packages/locales/zh-CN.po
+++ b/packages/locales/zh-CN.po
@@ -410,7 +410,7 @@ msgstr "交易"
 
 #: apps/swap/components/Route.tsx
 msgid "Optimized route"
-msgstr ""
+msgstr "优化路线"
 
 #: apps/swap/components/CrossTransfer/TokenSelector/TokenSelectorDialog.tsx
 #: packages/compat/components/TokenSelector/TokenSelectorDialog.tsx
@@ -786,7 +786,7 @@ msgstr "浅色主题"
 
 #: apps/pool/components/PoolsSection/Tables/TableFilters/TableFilters.tsx
 msgid "Farms"
-msgstr ""
+msgstr "农场"
 
 #: packages/wagmi/hooks/referrals/useSetCodeReview.ts
 msgid "Setting referral code ({code})"
@@ -1170,10 +1170,6 @@ msgstr "最佳奖励年化百分比："
 #: packages/wagmi/components/NotificationCentre/NotificationCentre.tsx
 msgid "Clear"
 msgstr "清除"
-
-#: packages/wagmi/components/Wallet/Button.tsx
-#~ msgid "Authorize Wallet"
-#~ msgstr "授权钱包"
 
 #: apps/pool/components/RemoveSection/RemoveSectionStable.tsx
 #: apps/pool/components/RemoveSection/RemoveSectionStandard.tsx

--- a/packages/locales/zh-TW.po
+++ b/packages/locales/zh-TW.po
@@ -410,7 +410,7 @@ msgstr "交易"
 
 #: apps/swap/components/Route.tsx
 msgid "Optimized route"
-msgstr ""
+msgstr "優化路線"
 
 #: apps/swap/components/CrossTransfer/TokenSelector/TokenSelectorDialog.tsx
 #: packages/compat/components/TokenSelector/TokenSelectorDialog.tsx
@@ -786,7 +786,7 @@ msgstr "淺色主題"
 
 #: apps/pool/components/PoolsSection/Tables/TableFilters/TableFilters.tsx
 msgid "Farms"
-msgstr ""
+msgstr "農場"
 
 #: packages/wagmi/hooks/referrals/useSetCodeReview.ts
 msgid "Setting referral code ({code})"
@@ -1170,10 +1170,6 @@ msgstr "最佳獎勵年利率："
 #: packages/wagmi/components/NotificationCentre/NotificationCentre.tsx
 msgid "Clear"
 msgstr "清除"
-
-#: packages/wagmi/components/Wallet/Button.tsx
-#~ msgid "Authorize Wallet"
-#~ msgstr "授權錢包"
 
 #: apps/pool/components/RemoveSection/RemoveSectionStable.tsx
 #: apps/pool/components/RemoveSection/RemoveSectionStandard.tsx

--- a/scripts/gpt-trans-locales.ts
+++ b/scripts/gpt-trans-locales.ts
@@ -1,7 +1,7 @@
 import { promises as fs } from 'node:fs'
 import { fileURLToPath } from 'node:url'
 import { ChatGPTAPI } from 'chatgpt'
-import proxy from 'https-proxy-agent'
+import { HttpsProxyAgent } from 'https-proxy-agent'
 import nodeFetch from 'node-fetch'
 import fg from 'fast-glob'
 import { oraPromise } from 'ora'
@@ -38,7 +38,7 @@ async function transAllLocalesFromGPT() {
     fetch: proxyUrl && proxyPort
       ? (url, options = {}) => {
           const defaultOptions = {
-            agent: proxy(`${proxyUrl}:${proxyPort}`),
+            agent: new HttpsProxyAgent(`${proxyUrl}:${proxyPort}`),
           }
 
           // @ts-expect-error nocheck


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates dependencies and adds support for a new token on Arbitrum One. 

### Detailed summary
- Updates `pnpm` to version `8.6.2`
- Updates `node-fetch` to version `2.6.1`
- Updates `fast-glob` to version `3.2.5`
- Updates `https-proxy-agent` to version `5.0.0`
- Adds support for a new token `ARB` on Arbitrum One

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->