### PR TITLE
fix(polkadot): subscribe accounts in provider

### DIFF
--- a/packages/polkadot/hooks/useAccounts.ts
+++ b/packages/polkadot/hooks/useAccounts.ts
@@ -5,6 +5,7 @@ import { decodeAddress } from '@polkadot/util-crypto'
 import { useIsMounted } from '@zenlink-interface/hooks'
 import type { InjectedAccountWithMeta } from '@polkadot/extension-inject/types'
 import type { Connector } from '../types'
+import { useProviderAccounts } from './useApi'
 
 if (!console.assert) {
   console.assert = (condition, message) => {
@@ -48,20 +49,12 @@ function extractAccounts(accounts: InjectedAccountWithMeta[] = [], connector: Co
 export function useAccounts(connector?: Connector) {
   const isMounted = useIsMounted()
   const [state, setState] = useState<UseAccounts>(EMPTY)
+  const accounts = useProviderAccounts()
 
   useEffect(() => {
-    const subscription = import('@polkadot/extension-dapp')
-      .then(async ({ web3AccountsSubscribe }) => {
-        return web3AccountsSubscribe((accounts) => {
-          isMounted && connector && setState(extractAccounts(accounts, connector))
-        })
-      }).catch(() => {})
-
-    return () => {
-      if (subscription)
-        subscription.then(unsub => unsub?.())
-    }
-  }, [connector, isMounted])
+    if (isMounted && connector)
+      setState(extractAccounts(accounts, connector))
+  }, [accounts, connector, isMounted])
 
   return state
 }

--- a/packages/polkadot/hooks/useApi.ts
+++ b/packages/polkadot/hooks/useApi.ts
@@ -1,5 +1,6 @@
 import type { ApiPromise } from '@polkadot/api'
 import { useContext, useMemo } from 'react'
+import type { InjectedAccountWithMeta } from '@polkadot/extension-inject/types'
 import type { ApiState } from '..'
 import { PolkadotApiContext } from '../components'
 
@@ -31,4 +32,12 @@ export const useApiStates = (chainId?: number): ApiState | undefined => {
     () => chainId ? context.states[chainId] : undefined,
     [chainId, context.states],
   )
+}
+
+export const useProviderAccounts = (): InjectedAccountWithMeta[] | undefined => {
+  const context = useContext(PolkadotApiContext)
+  if (!context)
+    throw new Error('Hook can only be used inside Polkadot Api Context')
+
+  return context.accounts
 }

--- a/packages/polkadot/types.ts
+++ b/packages/polkadot/types.ts
@@ -1,6 +1,6 @@
 import type { ApiPromise } from '@polkadot/api'
 import type { SubmittableExtrinsicFunction } from '@polkadot/api/promise/types'
-import type { InjectedExtension } from '@polkadot/extension-inject/types'
+import type { InjectedAccountWithMeta, InjectedExtension } from '@polkadot/extension-inject/types'
 import type { ChainProperties, ChainType } from '@polkadot/types/interfaces'
 import type { ParaChain } from '@zenlink-interface/polkadot-config'
 
@@ -42,6 +42,7 @@ export interface ApiContext {
   apis: Record<number, ApiPromise | undefined>
   apiError: string | null
   extensions?: InjectedExtension[]
+  accounts?: InjectedAccountWithMeta[]
   chainsConfig: ParaChain[]
   isWaitingInjected: boolean
 }


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR adds a new hook `useProviderAccounts` to get the list of accounts from the Polkadot API context. It also updates the `PolkadotApiProvider` component to subscribe to changes in the list of accounts and update the context accordingly.

### Detailed summary
- Adds a new hook `useProviderAccounts` to get the list of accounts from the Polkadot API context
- Updates `PolkadotApiProvider` to subscribe to changes in the list of accounts and update the context accordingly

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->