### PR TITLE
fix(pool):fixed position limit and table rendering

### DIFF
--- a/apps/pool/components/PoolsSection/Tables/PositionsTable/PositionsTable.tsx
+++ b/apps/pool/components/PoolsSection/Tables/PositionsTable/PositionsTable.tsx
@@ -66,15 +66,17 @@ export const PositionsTable: FC = () => {
     [sorting, query, extraQuery],
   )
 
+  const swrArgs = useMemo(() => ({
+    url: address ? `/pool/api/user/${address}` : null,
+    args,
+  }), [address, args])
+
   const { data: userPools, isValidating } = useSWR<LiquidityPosition<POOL_TYPE>[]>(
-    {
-      url: address ? `/pool/api/user/${address}` : null,
-      args,
-    },
+    swrArgs,
     fetcher,
   )
 
-  const table = useReactTable<LiquidityPosition<POOL_TYPE>>({
+  const tableOptions = useMemo(() => ({
     data: userPools || [],
     state: {
       sorting,
@@ -84,7 +86,9 @@ export const PositionsTable: FC = () => {
     onSortingChange: setSorting,
     getCoreRowModel: getCoreRowModel(),
     getSortedRowModel: getSortedRowModel(),
-  })
+  }), [columnVisibility, sorting, userPools])
+
+  const table = useReactTable<LiquidityPosition<POOL_TYPE>>(tableOptions)
 
   useEffect(() => {
     if (isSm && !isMd)

--- a/packages/graph-client/src/queries/userPools.ts
+++ b/packages/graph-client/src/queries/userPools.ts
@@ -220,11 +220,11 @@ const USER_POOLS_FETCH = gql`
 
 const defaultUserPoolsFetcherParams: Omit<UserPoolsQueryVariables, 'id'> = {
   pairPositionsWhere: { liquidityTokenBalance_gt: '0' },
-  pairPositionsLimit: 10,
+  pairPositionsLimit: 100,
   pairDayDataOrderBy: PairDayDataOrderByInput.DateDesc,
   pairDayDataLimit: 7,
   stableSwapPositionsWhere: { liquidityTokenBalance_gt: '0' },
-  stableSwapPositionsLimit: 10,
+  stableSwapPositionsLimit: 100,
   stableSwapDayDataOrderBy: StableSwapDayDataOrderByInput.DateDesc,
   stableSwapDayDataLimit: 7,
 }


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
### Detailed summary
- Increased the `pairPositionsLimit` from 10 to 100 in the `defaultUserPoolsFetcherParams` object in the `userPools.ts` file.
- Increased the `stableSwapPositionsLimit` from 10 to 100 in the `defaultUserPoolsFetcherParams` object in the `userPools.ts` file.
- Refactored the `useSWR` hook in the `PositionsTable.tsx` file to use the `swrArgs` object for the URL and arguments.
- Updated the `tableOptions` object in the `PositionsTable.tsx` file to include the `columnVisibility`, `sorting`, and `userPools` dependencies.
- Updated the `table` object in the `PositionsTable.tsx` file to use the `tableOptions` object for configuration.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->