### PR TITLE
fix(smart-router): check `OutOfReserve` for `UniV3Pool`

### DIFF
--- a/packages/config/router/src/index.ts
+++ b/packages/config/router/src/index.ts
@@ -60,9 +60,8 @@ export const BASES_TO_CHECK_TRADES_AGAINST: { readonly [chainId: number]: Token[
   ],
   [ParachainId.MOONBEAM]: [
     WNATIVE[ParachainId.MOONBEAM],
-    // FRAX[ParachainId.MOONBEAM],
-    // USDC[ParachainId.MOONBEAM],
-    // USDT[ParachainId.MOONBEAM],
+    USDC[ParachainId.MOONBEAM],
+    USDT[ParachainId.MOONBEAM],
     DOT[ParachainId.MOONBEAM],
   ],
   [ParachainId.SCROLL_ALPHA]: [

--- a/packages/config/wagmi/index.ts
+++ b/packages/config/wagmi/index.ts
@@ -45,11 +45,13 @@ export const moonbeam = {
   rpcUrls: {
     default: {
       http: [
+        'https://moonbeam.public.blastapi.io',
         'https://rpc.api.moonbeam.network',
       ],
     },
     public: {
       http: [
+        'https://moonbeam.public.blastapi.io',
         'https://rpc.api.moonbeam.network',
       ],
     },

--- a/packages/smart-router/src/liquidity-providers/AlgebraBase.ts
+++ b/packages/smart-router/src/liquidity-providers/AlgebraBase.ts
@@ -17,7 +17,7 @@ interface PoolInfo {
 }
 
 export abstract class AlgebraBaseProvider extends LiquidityProvider {
-  public readonly BIT_AMOUNT = 24
+  public readonly BIT_AMOUNT = 48
   public poolCodes: PoolCode[] = []
 
   public readonly initialPools: Map<string, PoolInfo> = new Map()


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
### Detailed summary
- Added `https://moonbeam.public.blastapi.io` to the `http` array in the `default` and `public` sections of `packages/config/wagmi/index.ts`.
- Changed the value of `BIT_AMOUNT` from 24 to 48 in `packages/smart-router/src/liquidity-providers/AlgebraBase.ts`.
- Updated the token list in the `MOONBEAM` section of `packages/config/router/src/index.ts`.
- Added an import statement for `getNumber` from `../../util` in `packages/smart-router/src/entities/pools/UniV3Pool.ts`.
- Modified the return values in the `swapExactAmountOut` method of `UniV3Pool` in `packages/smart-router/src/entities/pools/UniV3Pool.ts`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->