### PR TITLE
feat(smart-router): impl Curve and `d2O` on moonbeam

### DIFF
--- a/packages/config/router/src/index.ts
+++ b/packages/config/router/src/index.ts
@@ -63,6 +63,13 @@ export const BASES_TO_CHECK_TRADES_AGAINST: { readonly [chainId: number]: Token[
     USDC[ParachainId.MOONBEAM],
     USDT[ParachainId.MOONBEAM],
     DOT[ParachainId.MOONBEAM],
+    new Token({
+      chainId: ParachainId.MOONBEAM,
+      address: '0xc806B0600cbAfA0B197562a9F7e3B9856866E9bF',
+      decimals: 18,
+      name: 'Deuterium',
+      symbol: 'd2O',
+    }),
   ],
   [ParachainId.SCROLL_ALPHA]: [
     WNATIVE[ParachainId.SCROLL_ALPHA],

--- a/packages/smart-router/src/liquidity-providers/CurveStable.ts
+++ b/packages/smart-router/src/liquidity-providers/CurveStable.ts
@@ -23,6 +23,16 @@ export class CurveStableProvider extends CurveStableBaseProvider {
         '0xC9B8a3FDECB9D5b218d02555a8Baf332E5B740d5', // FRAXBP
       ],
     ],
+    [ParachainId.MOONBEAM]: [
+      [
+        '0xFF6DD348e6eecEa2d81D4194b60c5157CD9e64f4', // d2o-usdt
+        [
+          '0xc806B0600cbAfA0B197562a9F7e3B9856866E9bF', // d2o
+          '0xFFFFFFfFea09FB06d082fd1275CD48b191cbCD1d', // usdt
+        ],
+        '0xFF6DD348e6eecEa2d81D4194b60c5157CD9e64f4', // d2oUSDT-f
+      ],
+    ],
   }
 
   metaPools: { [chainId: number]: [string, string[], string, string][] } = {

--- a/packages/token-lists/lists/moonbeam.json
+++ b/packages/token-lists/lists/moonbeam.json
@@ -48,6 +48,17 @@
     },
     {
       "networkId": 300,
+      "address": "0xc806B0600cbAfA0B197562a9F7e3B9856866E9bF",
+      "parachainId": 2004,
+      "ethereumChainId": 1284,
+      "assetType": 255,
+      "assetIndex": 0,
+      "symbol": "d2O",
+      "decimals": 18,
+      "name": "Deuterium"
+    },
+    {
+      "networkId": 300,
       "address": "0x511ab53f793683763e5a8829738301368a2411e3",
       "parachainId": 2004,
       "ethereumChainId": 1284,


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
### Focus of this PR:
This PR focuses on adding support for the Deuterium (d2O) token and the Moonbeam network.

### Detailed summary:
- Added support for the Deuterium (d2O) token on the Moonbeam network.
- Added the Deuterium (d2O) token to the Moonbeam token list.
- Added a new liquidity provider for the Deuterium (d2O) token on the Moonbeam network.
- Added an executor address for the Moonbeam network.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->