### PR TITLE
Enable amplitude config

### DIFF
--- a/apps/pool/config.ts
+++ b/apps/pool/config.ts
@@ -12,7 +12,7 @@ export const AMM_ENABLED_NETWORKS = [
   ParachainId.MOONBEAM,
   ParachainId.BIFROST_KUSAMA,
   ParachainId.BIFROST_POLKADOT,
-  // ParachainId.AMPLITUDE,
+  ParachainId.AMPLITUDE,
 ]
 
 export const SUPPORTED_CHAIN_IDS = Array.from(

--- a/apps/swap/config.ts
+++ b/apps/swap/config.ts
@@ -6,7 +6,7 @@ export const AMM_ENABLED_NETWORKS = [
   ParachainId.MOONBEAM,
   ParachainId.BIFROST_KUSAMA,
   ParachainId.BIFROST_POLKADOT,
-  // ParachainId.AMPLITUDE,
+  ParachainId.AMPLITUDE,
 ]
 
 export const AGGREGATOR_ENABLED_NETWORKS = [

--- a/packages/chain/parachains.json
+++ b/packages/chain/parachains.json
@@ -55,7 +55,7 @@
     "name": "Amplitude",
     "chain": "Amplitude",
     "rpc": [
-      "wss://pencol-roa-00.pendulumchain.tech"
+      "wss://rpc-amplitude.pendulumchain.tech"
     ],
     "prefix": 57,
     "faucets": [],

--- a/packages/config/graph/src/index.ts
+++ b/packages/config/graph/src/index.ts
@@ -19,11 +19,11 @@ export const SQUID_HOST: Record<number | string, string> = {
   [ParachainId.BIFROST_POLKADOT]: `${SQUID_HOST_ENDPOINT}/zenlink-bifrost-polkadot/graphql`,
   [ParachainId.ARBITRUM_ONE]: 'https://api.thegraph.com/subgraphs/name/ianlapham/uniswap-arbitrum-one',
   [ParachainId.BASE]: 'https://api.studio.thegraph.com/query/48211/uniswap-v3-base/version/latest',
-  [ParachainId.AMPLITUDE]: `${SQUID_HOST_ENDPOINT}/foucoco-squid/graphql`,
+  [ParachainId.AMPLITUDE]: `${SQUID_HOST_ENDPOINT}/amplitude-squid/graphql`,
 }
 
 export const ARCHIVE_HOST: Record<number | string, string> = {
   [ParachainId.BIFROST_KUSAMA]: 'https://bifrost.explorer.subsquid.io/graphql',
   [ParachainId.BIFROST_POLKADOT]: 'https://bifrost-polkadot.explorer.subsquid.io/graphql',
-  [ParachainId.AMPLITUDE]: 'https://foucoco.explorer.subsquid.io/graphql',
+  [ParachainId.AMPLITUDE]: 'https://amplitude.explorer.subsquid.io/graphql',
 }

--- a/packages/config/polkadot/src/index.ts
+++ b/packages/config/polkadot/src/index.ts
@@ -81,7 +81,7 @@ export const parachains: ParaChain[] = [
     network: 'amplitude',
     nativeCurrency: { name: 'Amplitude', symbol: 'AMPE', decimals: 12 },
     endpoints: [
-      'wss://pencol-roa-00.pendulumchain.tech',
+      'wss://rpc-amplitude.pendulumchain.tech',
     ],
     blockExplorers: {
       default: {


### PR DESCRIPTION
This PR enables the temporarily disabled Amplitude network for the swap and pool apps and changes the used endpoints from Foucoco to Amplitude.

## Important
Please don't merge this PR right away. We are currently creating a referendum for the creation of a pool but the transaction will only be executed mid of next week. We'd like to merge this within three days of when the bootstrapping starts, so towards the end of next week. I will ping again and mark this as ready for review once it can get merged. 

<!-- start pr-codex -->

---

## PR-Codex overview
### Focus of the PR:
This PR focuses on updating the configuration and endpoints for the Amplitude parachain.

### Detailed summary:
- Updated the ParachainId for Amplitude in `config.ts` files.
- Updated the RPC endpoint for Amplitude in `parachains.json` and `config.ts` files.
- Updated the native currency and endpoints for Amplitude in `index.ts` files.
- Updated the GraphQL endpoint for Amplitude in `index.ts` files.
- Updated the archive host for Amplitude in `index.ts` files.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->