### PR TITLE
feat(currency): add `USDC` on base

### DIFF
--- a/packages/config/router/src/index.ts
+++ b/packages/config/router/src/index.ts
@@ -82,6 +82,13 @@ export const BASES_TO_CHECK_TRADES_AGAINST: { readonly [chainId: number]: Token[
     DAI[ParachainId.BASE],
     new Token({
       chainId: ParachainId.BASE,
+      address: '0xd9aAEc86B65D86f6A7B5B1b0c42FFA531710b6CA',
+      decimals: 6,
+      symbol: 'USDbc',
+      name: 'USD Base Coin',
+    }),
+    new Token({
+      chainId: ParachainId.BASE,
       address: '0xEB466342C4d449BC9f53A865D5Cb90586f405215',
       decimals: 6,
       name: 'Axelar Wrapped USDC',
@@ -146,6 +153,7 @@ export const COMMON_BASES: { readonly [chainId: number]: Type[] } = {
   ],
   [ParachainId.BASE]: [
     Native.onChain(ParachainId.BASE),
+    USDC[ParachainId.BASE],
     new Token({
       chainId: ParachainId.BASE,
       address: '0xd9aAEc86B65D86f6A7B5B1b0c42FFA531710b6CA',

--- a/packages/currency/src/constants/tokenAddresses.ts
+++ b/packages/currency/src/constants/tokenAddresses.ts
@@ -46,6 +46,7 @@ export const USDC_ADDRESS: Record<number | string, string> = {
   [ParachainId.ASTAR]: '0x6a2d262D56735DbA19Dd70682B39F6bE9a931D98',
   [ParachainId.ARBITRUM_ONE]: '0xaf88d065e77c8cC2239327C5EDb3A432268e5831',
   [ParachainId.SCROLL_ALPHA]: '0x67aE69Fd63b4fc8809ADc224A9b82Be976039509',
+  [ParachainId.BASE]: '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913',
 }
 
 export const USDT_ADDRESS: Record<number | string, string> = {
@@ -59,6 +60,7 @@ export const DAI_ADDRESS: Record<number | string, string> = {
   [ParachainId.ASTAR]: '0x6De33698e9e9b787e09d3Bd7771ef63557E148bb',
   [ParachainId.ARBITRUM_ONE]: '0xDA10009cBd5D07dd0CeCc66161FC93D7c9000da1',
   [ParachainId.SCROLL_ALPHA]: '0x4702E5AEb70BdC05B11F8d8E701ad000dc85bD44',
+  [ParachainId.BASE]: '0x50c5725949A6F0c72E6C4a641F24049A917DB0Cb',
 }
 
 export const FRAX_ADDRESS: Record<number | string, string> = {

--- a/packages/currency/src/constants/tokens.ts
+++ b/packages/currency/src/constants/tokens.ts
@@ -138,13 +138,6 @@ export const USDC = {
     symbol: 'USDC.wh',
     name: 'USD Coin (Wormhole)',
   }),
-  [ParachainId.BASE]: new Token({
-    chainId: ParachainId.BASE,
-    address: '0xd9aAEc86B65D86f6A7B5B1b0c42FFA531710b6CA',
-    decimals: 6,
-    symbol: 'USDbc',
-    name: 'USD Base Coin',
-  }),
 } as { [k: string]: Token }
 
 export const USDT = {
@@ -181,13 +174,6 @@ export const DAI = {
     },
     DAI_ADDRESS,
   ),
-  [ParachainId.BASE]: new Token({
-    chainId: ParachainId.BASE,
-    address: '0x50c5725949A6F0c72E6C4a641F24049A917DB0Cb',
-    decimals: 18,
-    symbol: 'DAI',
-    name: 'Dai Stablecoin',
-  }),
 } as { [k: string]: Token }
 
 export const FRAX = addressMapToTokenMap(

--- a/packages/smart-router/src/liquidity-providers/CurveStable.ts
+++ b/packages/smart-router/src/liquidity-providers/CurveStable.ts
@@ -41,7 +41,17 @@ export class CurveStableProvider extends CurveStableBaseProvider {
           '0xEB466342C4d449BC9f53A865D5Cb90586f405215', // axlUSDC
           '0x417Ac0e078398C154EdFadD9Ef675d30Be60Af93', // crvUSD
         ],
-        '0xFF6DD348e6eecEa2d81D4194b60c5157CD9e64f4', // 3c-f
+        '0xA450487D8C8F355611EFF9553337BE67261Af26f', // 3c-f
+      ],
+      [
+        '0xf6C5F01C7F3148891ad0e19DF78743D31E390D1f', // 4pool
+        [
+          '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913', // USDC
+          '0xd9aAEc86B65D86f6A7B5B1b0c42FFA531710b6CA', // USDbc
+          '0xEB466342C4d449BC9f53A865D5Cb90586f405215', // axlUSDC
+          '0x417Ac0e078398C154EdFadD9Ef675d30Be60Af93', // crvUSD
+        ],
+        '0xf6C5F01C7F3148891ad0e19DF78743D31E390D1f', // '4poolUSD-f
       ],
     ],
   }

--- a/packages/token-lists/lists/base.json
+++ b/packages/token-lists/lists/base.json
@@ -19,6 +19,17 @@
       "ethereumChainId": 8453,
       "assetType": 255,
       "assetIndex": 0,
+      "address": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+      "decimals": 6,
+      "name": "USD Coin",
+      "symbol": "USDC"
+    },
+    {
+      "networkId": 300,
+      "parachainId": 8453,
+      "ethereumChainId": 8453,
+      "assetType": 255,
+      "assetIndex": 0,
       "address": "0xd9aAEc86B65D86f6A7B5B1b0c42FFA531710b6CA",
       "decimals": 6,
       "name": "USD Base Coin",


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
### Focus of this PR:
Add USD Coin (USDC) as a supported token and update token addresses for the BASE parachain.

### Detailed summary:
- Added USD Coin (USDC) as a supported token with the following details:
  - Network ID: 300
  - Parachain ID: 8453
  - Ethereum Chain ID: 8453
  - Asset Type: 255
  - Asset Index: 0
  - Address: 0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913
  - Decimals: 6
  - Name: USD Coin
  - Symbol: USDC
- Updated the token address for USDbc to '0xd9aAEc86B65D86f6A7B5B1b0c42FFA531710b6CA' with the name 'USD Base Coin'.
- Updated the token address for USDT on the BASE parachain to '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913'.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->