### PR TITLE
feat(graph-client): migrate to `ArrowSquid`

### DIFF
--- a/packages/config/graph/src/index.ts
+++ b/packages/config/graph/src/index.ts
@@ -14,7 +14,7 @@ export const SQUID_HOST_ENDPOINT = 'https://squid.subsquid.io'
 export const SQUID_HOST: Record<number | string, string> = {
   [ParachainId.ASTAR]: `${SQUID_HOST_ENDPOINT}/zenlink-astar/graphql`,
   [ParachainId.MOONRIVER]: `${SQUID_HOST_ENDPOINT}/zenlink-moonriver/graphql`,
-  [ParachainId.MOONBEAM]: `${SQUID_HOST_ENDPOINT}/zenlink-moonbeam-squid/graphql`,
+  [ParachainId.MOONBEAM]: `${SQUID_HOST_ENDPOINT}/zenlink-moonbeam/graphql`,
   [ParachainId.BIFROST_KUSAMA]: `${SQUID_HOST_ENDPOINT}/zenlink-bifrost-kusama-squid/graphql`,
   [ParachainId.BIFROST_POLKADOT]: `${SQUID_HOST_ENDPOINT}/zenlink-bifrost-polkadot/graphql`,
   [ParachainId.ARBITRUM_ONE]: 'https://api.thegraph.com/subgraphs/name/ianlapham/uniswap-arbitrum-one',

--- a/packages/graph-client/src/apollo-codegen.ts
+++ b/packages/graph-client/src/apollo-codegen.ts
@@ -8,7 +8,7 @@ const config: CodegenConfig = {
     'src/__generated__/types-and-hooks.ts': {
       schema: [
         // Exchange Schema
-        // 'https://squid.subsquid.io/Zenlink-Astar-Squid/graphql',
+        // 'https://squid.subsquid.io/zenlink-astar/graphql',
         'https://squid.subsquid.io/zenlink-bifrost-kusama-squid/graphql',
         // Archive Schema
         'https://bifrost.explorer.subsquid.io/graphql',


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates the GraphQL endpoints for the Zenlink Astar and Zenlink Moonbeam parachains.

### Detailed summary
- Updated the GraphQL endpoint for Zenlink Astar from 'https://squid.subsquid.io/Zenlink-Astar-Squid/graphql' to 'https://squid.subsquid.io/zenlink-astar/graphql'
- Updated the GraphQL endpoint for Zenlink Moonbeam from `${SQUID_HOST_ENDPOINT}/zenlink-moonbeam-squid/graphql` to `${SQUID_HOST_ENDPOINT}/zenlink-moonbeam/graphql`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->