### PR TITLE
fix(referrals): prepareSendTransaction fix for safe sdk

### DIFF
--- a/packages/wagmi/hooks/referrals/useSetCodeReview.ts
+++ b/packages/wagmi/hooks/referrals/useSetCodeReview.ts
@@ -98,6 +98,7 @@ export const useSetCodeReview: UseSetCodeReview = ({
   const [request, setRequest] = useState<WagmiTransactionRequest>()
   const { config } = usePrepareSendTransaction({
     ...request,
+    value: BigInt(0), // Issue https://github.com/wagmi-dev/wagmi/issues/2887
     chainId: ethereumChainId,
     enabled: !!code && !!request,
   })


### PR DESCRIPTION
Hello! I am suggesting (once again) a minor update to let safe users interact with the referral page (if it is intended that way).

Thank you!

## Changes
Only one line is changed. It is related to the **value** property being set to 0 if no native token is transferred.

## Issue:
- Safe users can not interact with referral functionality:
![image](https://github.com/zenlinkpro/zenlink-interface/assets/65896721/400c7012-d2d6-4d06-abd0-3219f6ed2509)

## Result
Safe users can use referral codes.


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on resolving the issue https://github.com/wagmi-dev/wagmi/issues/2887 by setting the value of `request` to `BigInt(0)`. 

### Detailed summary:
- Set the value of `request` to `BigInt(0)`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->