### PR TITLE
Check for farming rpc functions

### DIFF
--- a/packages/parachains-impl/amplitude/hooks/useFarmRewards.ts
+++ b/packages/parachains-impl/amplitude/hooks/useFarmRewards.ts
@@ -101,6 +101,9 @@ export const useFarmsRewards: UseFarmsRewards = ({
     if (!api || !account || !isAccount(account))
       return
 
+    if (!api.rpc.farming.getFarmingRewards || !api.rpc.farming.getGaugeRewards)
+      return
+
     try {
       Promise.all(
         pids.map((pid) => {

--- a/packages/parachains-impl/bifrost/hooks/useFarmRewards.ts
+++ b/packages/parachains-impl/bifrost/hooks/useFarmRewards.ts
@@ -101,6 +101,9 @@ export const useFarmsRewards: UseFarmsRewards = ({
     if (!api || !isAccount(account))
       return
 
+    if (!api.rpc.farming.getFarmingRewards || !api.rpc.farming.getGaugeRewards)
+      return
+
     Promise.all(
       pids.map(pid => Promise.all([
         api.rpc.farming.getFarmingRewards(...[account, Number(pid)]),


### PR DESCRIPTION
This PR adds additional checks if the farming RPC functions are available.
This fixes a problem on Amplitude. I had to also add these changes to the bifrost implementation though, because both hooks will fire when connected to the Amplitude network, thus both implementations need this check.

<!-- start pr-codex -->

---

## PR-Codex overview
### Focus of the PR:
Fixing the useFarmRewards hook in the `parachains-impl` and `bifrost` packages.

### Detailed summary:
- Added a check for the existence of `api.rpc.farming.getFarmingRewards` and `api.rpc.farming.getGaugeRewards` before proceeding with the code execution.
- Wrapped the code inside a `try-catch` block to handle any potential errors.
- Reorganized the code structure for better readability.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->