### PR TITLE
feat(smart-router): add `xcEQD` on moonbeam

### DIFF
--- a/packages/config/router/src/index.ts
+++ b/packages/config/router/src/index.ts
@@ -60,6 +60,7 @@ export const BASES_TO_CHECK_TRADES_AGAINST: { readonly [chainId: number]: Token[
   ],
   [ParachainId.MOONBEAM]: [
     WNATIVE[ParachainId.MOONBEAM],
+    FRAX[ParachainId.MOONBEAM],
     USDC[ParachainId.MOONBEAM],
     USDT[ParachainId.MOONBEAM],
     DOT[ParachainId.MOONBEAM],
@@ -69,6 +70,20 @@ export const BASES_TO_CHECK_TRADES_AGAINST: { readonly [chainId: number]: Token[
       decimals: 18,
       name: 'Deuterium',
       symbol: 'd2O',
+    }),
+    new Token({
+      chainId: ParachainId.MOONBEAM,
+      address: '0xCa01a1D0993565291051daFF390892518ACfAD3A',
+      decimals: 6,
+      name: 'Axelar Wrapped USDC',
+      symbol: 'axlUSDC',
+    }),
+    new Token({
+      chainId: ParachainId.MOONBEAM,
+      address: '0xFFffFfFF8cdA1707bAF23834d211B08726B1E499',
+      decimals: 9,
+      name: 'xcEQD',
+      symbol: 'xcEQD',
     }),
   ],
   [ParachainId.SCROLL_ALPHA]: [

--- a/packages/smart-router/src/liquidity-providers/BeamStable.ts
+++ b/packages/smart-router/src/liquidity-providers/BeamStable.ts
@@ -15,6 +15,14 @@ export class BeamStableProvider extends SaddleBaseProvider {
         ],
         '0x89cf45bbe0850c7b0d315a48730f6a602420f8be',
       ],
+      [
+        '0xfB911D231A1e671e68aA5F9aa540Ad4305f38409', // xcEQD-xcUSDT
+        [
+          '0xFFFFFFfFea09FB06d082fd1275CD48b191cbCD1d', // xcUSDT
+          '0xFFffFfFF8cdA1707bAF23834d211B08726B1E499', // xcEQD
+        ],
+        '0xe026b7d702aaf4b4a53b105e626a7998d4532781',
+      ],
     ],
   }
 

--- a/packages/token-lists/lists/moonbeam.json
+++ b/packages/token-lists/lists/moonbeam.json
@@ -191,6 +191,17 @@
     },
     {
       "networkId": 300,
+      "address": "0xFFffFfFF8cdA1707bAF23834d211B08726B1E499",
+      "parachainId": 2004,
+      "ethereumChainId": 1284,
+      "assetType": 255,
+      "assetIndex": 0,
+      "symbol": "xcEQD",
+      "decimals": 9,
+      "name": "xcEQD"
+    },
+    {
+      "networkId": 300,
       "address": "0xffffffff52c56a9257bb97f4b2b6f7b2d624ecda",
       "parachainId": 2004,
       "ethereumChainId": 1284,


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
### Focus of this PR:
This PR focuses on adding a new liquidity provider (`BeamStable`) and updating the token list with new tokens (`xcEQD` and `axlUSDC`). It also includes changes to the router configuration.

### Detailed summary:
- Added a new liquidity provider `BeamStable` with associated tokens.
- Updated the token list with the addition of `xcEQD` and `axlUSDC`.
- Updated the router configuration to include the new tokens.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->