### PR TITLE
fix: wagmi wallet autoconnect issue for safe users

### DIFF
--- a/packages/wagmi/client.ts
+++ b/packages/wagmi/client.ts
@@ -31,27 +31,30 @@ export const config = createConfig({
     warn: null,
   },
   connectors: [
-    new InjectedConnector({
-      chains,
-      options: {
-        shimDisconnect: true,
-      },
-    }),
-    new CoinbaseWalletConnector({
-      chains,
-      options: {
-        appName: 'zenlink-interface',
-      },
-    }),
-    new WalletConnectConnector({
-      chains,
-      options: {
-        projectId: '2d54460dfe49ac687751d282d0c54590',
-      },
-    }),
-    new TalismanConnector({ chains }),
-    new SubWalletConnector({ chains }),
-    new LedgerConnector({ chains, options: {} }),
-    ...(multisigConnector.ready ? [multisigConnector] : []),
+    ...(multisigConnector.ready
+      ? [multisigConnector]
+      : [
+          new InjectedConnector({
+            chains,
+            options: {
+              shimDisconnect: true,
+            },
+          }),
+          new CoinbaseWalletConnector({
+            chains,
+            options: {
+              appName: 'zenlink-interface',
+            },
+          }),
+          new WalletConnectConnector({
+            chains,
+            options: {
+              projectId: '2d54460dfe49ac687751d282d0c54590',
+            },
+          }),
+          new TalismanConnector({ chains }),
+          new SubWalletConnector({ chains }),
+          new LedgerConnector({ chains, options: {} }),
+        ]),
   ],
 })


### PR DESCRIPTION
Hello! I am proposing connector config change to tackle the issue with autoconnect with safe apps.

## Issue: safe users autoconnect to other providers (e.g. metamask) instead of safe. 
When users are connected to multiple providers (e.g. metamask and safe - wagmi will connect to metamask). More info here:
https://github.com/safe-global/safe-apps-sdk/blob/main/packages/safe-apps-wagmi/README.md?plain=1#L35

Meanwhile if opened in safe context - it should show the safe address (and disregard other connectors).
![image](https://github.com/zenlinkpro/zenlink-interface/assets/65896721/3df65687-fd4d-484f-866a-666c8eab0775)

## Proposed solution
- If app is opened in the safe context - load only safe connector, else (open through regular browser): use the default connector list.
- **Files changed:** client.ts

Now after refreshing - despite other tab being open and connected to metamask, if this app is opened in safe - it will prioritize safe connection:
![image](https://github.com/zenlinkpro/zenlink-interface/assets/65896721/c08b1aa4-f568-44c9-b56a-ad6ceac1fe86)




<!-- start pr-codex -->

---

## PR-Codex overview
### Focus of the PR:
This PR focuses on restructuring the code to conditionally include the `multisigConnector` in the `connectors` array.

### Detailed summary:
- The `multisigConnector` is now conditionally included in the `connectors` array based on its `ready` status.
- The code for the `multisigConnector` has been moved inside the conditional statement.
- The code for the other connectors remains unchanged.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->