### PR TITLE
feat(smart-router): support uniswap v3 on moonbeam

### DIFF
--- a/packages/smart-router/src/entities/poolCodes/UniV3PoolCode.ts
+++ b/packages/smart-router/src/entities/poolCodes/UniV3PoolCode.ts
@@ -11,6 +11,7 @@ export class UniV3PoolCode extends PoolCode {
   executor: { [chainId: number]: string } = {
     [ParachainId.SCROLL_ALPHA]: '0xB2c26294c3Fd8B73E887Bf9002fA70DbC6759841',
     [ParachainId.BASE]: '0x7B1128E610ae1d461B7B8227f9FBBB39e336c515',
+    [ParachainId.MOONBEAM]: '0x9587426f304eD59d15a8834bf0bA91B1872F3c24'
   } as const
 
   public constructor(pool: UniV3Pool, providerName: string) {

--- a/packages/smart-router/src/liquidity-providers/UniswapV3.ts
+++ b/packages/smart-router/src/liquidity-providers/UniswapV3.ts
@@ -10,11 +10,13 @@ export class UniswapV3Provider extends UniswapV3BaseProvider {
       [ParachainId.ARBITRUM_ONE]: '0x1f98431c8ad98523631ae4a59f267346ea31f984',
       [ParachainId.SCROLL_ALPHA]: '0x6E7E0d996eF50E289af9BFd93f774C566F014660',
       [ParachainId.BASE]: '0x33128a8fC17869897dcE68Ed026d694621f6FDfD',
+      [ParachainId.MOONBEAM]: '0x28f1158795A3585CaAA3cD6469CD65382b89BB70',
     } as const
     const stateMultiCall = {
       [ParachainId.ARBITRUM_ONE]: '0x7B1128E610ae1d461B7B8227f9FBBB39e336c515',
       [ParachainId.SCROLL_ALPHA]: '0xAFCCA0f68e0883b797c71525377DE46B2E65AB28',
       [ParachainId.BASE]: '0x87b7881128172F92964D9fa61D77cBa6B132873F',
+      [ParachainId.MOONBEAM]: '0x26DFc61329b6a2bBAb2D13f06Ec9B0C5cb2f1ABE',
     } as const
 
     super(chainId, client, factory, stateMultiCall)


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
### Focus of the PR:
This PR focuses on adding support for the Moonbeam parachain in the UniV3PoolCode and UniswapV3 classes.

### Detailed summary:
- Added the Moonbeam parachain ID and corresponding address in the UniV3PoolCode class.
- Added the Moonbeam parachain ID and corresponding address in the UniswapV3 class.
- Updated the stateMultiCall object in the UniswapV3 class to include the Moonbeam parachain ID and corresponding address.
- Modified the constructor of the UniswapV3 class to include the Moonbeam parachain ID and corresponding address in the super() method.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->