### PR TITLE
refactor(smart-router): use new state multicall

### DIFF
--- a/packages/smart-router/src/abis/algebraStateMulticall.ts
+++ b/packages/smart-router/src/abis/algebraStateMulticall.ts
@@ -37,11 +37,6 @@ export const algebraStateMulticall = [
             type: 'address',
           },
           {
-            internalType: 'uint256',
-            name: 'blockTimestamp',
-            type: 'uint256',
-          },
-          {
             components: [
               {
                 internalType: 'uint160',
@@ -59,27 +54,12 @@ export const algebraStateMulticall = [
                 type: 'int24',
               },
               {
-                internalType: 'uint16',
-                name: 'observationIndex',
-                type: 'uint16',
-              },
-              {
-                internalType: 'uint8',
-                name: 'communityFeeToken0',
-                type: 'uint8',
-              },
-              {
-                internalType: 'uint8',
-                name: 'communityFeeToken1',
-                type: 'uint8',
-              },
-              {
                 internalType: 'bool',
                 name: 'unlocked',
                 type: 'bool',
               },
             ],
-            internalType: 'struct AlgebraStateMulticall.Slot0',
+            internalType: 'struct AlgebraV1StateMulticall.Slot0',
             name: 'slot0',
             type: 'tuple',
           },
@@ -94,11 +74,6 @@ export const algebraStateMulticall = [
             type: 'int24',
           },
           {
-            internalType: 'uint128',
-            name: 'maxLiquidityPerTick',
-            type: 'uint128',
-          },
-          {
             internalType: 'uint256',
             name: 'balance0',
             type: 'uint256',
@@ -111,98 +86,22 @@ export const algebraStateMulticall = [
           {
             components: [
               {
-                internalType: 'uint32',
-                name: 'blockTimestamp',
-                type: 'uint32',
-              },
-              {
-                internalType: 'int56',
-                name: 'tickCumulative',
-                type: 'int56',
-              },
-              {
-                internalType: 'uint160',
-                name: 'secondsPerLiquidityCumulativeX128',
-                type: 'uint160',
-              },
-              {
-                internalType: 'bool',
-                name: 'initialized',
-                type: 'bool',
-              },
-            ],
-            internalType: 'struct AlgebraStateMulticall.Observation',
-            name: 'observation',
-            type: 'tuple',
-          },
-          {
-            components: [
-              {
-                internalType: 'int16',
-                name: 'index',
-                type: 'int16',
-              },
-              {
-                internalType: 'uint256',
-                name: 'value',
-                type: 'uint256',
-              },
-            ],
-            internalType: 'struct AlgebraStateMulticall.TickBitMapMappings[]',
-            name: 'tickBitmap',
-            type: 'tuple[]',
-          },
-          {
-            components: [
-              {
                 internalType: 'int24',
                 name: 'index',
                 type: 'int24',
               },
               {
-                components: [
-                  {
-                    internalType: 'uint128',
-                    name: 'liquidityGross',
-                    type: 'uint128',
-                  },
-                  {
-                    internalType: 'int128',
-                    name: 'liquidityNet',
-                    type: 'int128',
-                  },
-                  {
-                    internalType: 'int56',
-                    name: 'tickCumulativeOutside',
-                    type: 'int56',
-                  },
-                  {
-                    internalType: 'uint160',
-                    name: 'secondsPerLiquidityOutsideX128',
-                    type: 'uint160',
-                  },
-                  {
-                    internalType: 'uint32',
-                    name: 'secondsOutside',
-                    type: 'uint32',
-                  },
-                  {
-                    internalType: 'bool',
-                    name: 'initialized',
-                    type: 'bool',
-                  },
-                ],
-                internalType: 'struct AlgebraStateMulticall.TickInfo',
+                internalType: 'int256',
                 name: 'value',
-                type: 'tuple',
+                type: 'int256',
               },
             ],
-            internalType: 'struct AlgebraStateMulticall.TickInfoMappings[]',
-            name: 'ticks',
+            internalType: 'struct AlgebraV1StateMulticall.TickBitMapMappings[]',
+            name: 'tickBitmap',
             type: 'tuple[]',
           },
         ],
-        internalType: 'struct AlgebraStateMulticall.StateResult',
+        internalType: 'struct AlgebraV1StateMulticall.StateResult',
         name: 'state',
         type: 'tuple',
       },

--- a/packages/smart-router/src/abis/uniswapV3StateMulticall.ts
+++ b/packages/smart-router/src/abis/uniswapV3StateMulticall.ts
@@ -42,11 +42,6 @@ export const uniswapV3StateMulticall = [
             type: 'address',
           },
           {
-            internalType: 'uint256',
-            name: 'blockTimestamp',
-            type: 'uint256',
-          },
-          {
             components: [
               {
                 internalType: 'uint160',
@@ -59,21 +54,6 @@ export const uniswapV3StateMulticall = [
                 type: 'int24',
               },
               {
-                internalType: 'uint16',
-                name: 'observationIndex',
-                type: 'uint16',
-              },
-              {
-                internalType: 'uint16',
-                name: 'observationCardinality',
-                type: 'uint16',
-              },
-              {
-                internalType: 'uint16',
-                name: 'observationCardinalityNext',
-                type: 'uint16',
-              },
-              {
                 internalType: 'uint8',
                 name: 'feeProtocol',
                 type: 'uint8',
@@ -84,7 +64,7 @@ export const uniswapV3StateMulticall = [
                 type: 'bool',
               },
             ],
-            internalType: 'struct IUniswapV3StateMulticall.Slot0',
+            internalType: 'struct UniswapV3StateMulticall.Slot0',
             name: 'slot0',
             type: 'tuple',
           },
@@ -99,11 +79,6 @@ export const uniswapV3StateMulticall = [
             type: 'int24',
           },
           {
-            internalType: 'uint128',
-            name: 'maxLiquidityPerTick',
-            type: 'uint128',
-          },
-          {
             internalType: 'uint256',
             name: 'balance0',
             type: 'uint256',
@@ -116,98 +91,22 @@ export const uniswapV3StateMulticall = [
           {
             components: [
               {
-                internalType: 'uint32',
-                name: 'blockTimestamp',
-                type: 'uint32',
-              },
-              {
-                internalType: 'int56',
-                name: 'tickCumulative',
-                type: 'int56',
-              },
-              {
-                internalType: 'uint160',
-                name: 'secondsPerLiquidityCumulativeX128',
-                type: 'uint160',
-              },
-              {
-                internalType: 'bool',
-                name: 'initialized',
-                type: 'bool',
-              },
-            ],
-            internalType: 'struct IUniswapV3StateMulticall.Observation',
-            name: 'observation',
-            type: 'tuple',
-          },
-          {
-            components: [
-              {
-                internalType: 'int16',
-                name: 'index',
-                type: 'int16',
-              },
-              {
-                internalType: 'uint256',
-                name: 'value',
-                type: 'uint256',
-              },
-            ],
-            internalType: 'struct IUniswapV3StateMulticall.TickBitMapMappings[]',
-            name: 'tickBitmap',
-            type: 'tuple[]',
-          },
-          {
-            components: [
-              {
                 internalType: 'int24',
                 name: 'index',
                 type: 'int24',
               },
               {
-                components: [
-                  {
-                    internalType: 'uint128',
-                    name: 'liquidityGross',
-                    type: 'uint128',
-                  },
-                  {
-                    internalType: 'int128',
-                    name: 'liquidityNet',
-                    type: 'int128',
-                  },
-                  {
-                    internalType: 'int56',
-                    name: 'tickCumulativeOutside',
-                    type: 'int56',
-                  },
-                  {
-                    internalType: 'uint160',
-                    name: 'secondsPerLiquidityOutsideX128',
-                    type: 'uint160',
-                  },
-                  {
-                    internalType: 'uint32',
-                    name: 'secondsOutside',
-                    type: 'uint32',
-                  },
-                  {
-                    internalType: 'bool',
-                    name: 'initialized',
-                    type: 'bool',
-                  },
-                ],
-                internalType: 'struct IUniswapV3StateMulticall.TickInfo',
+                internalType: 'int256',
                 name: 'value',
-                type: 'tuple',
+                type: 'int256',
               },
             ],
-            internalType: 'struct IUniswapV3StateMulticall.TickInfoMappings[]',
-            name: 'ticks',
+            internalType: 'struct UniswapV3StateMulticall.TickBitMapMappings[]',
+            name: 'tickBitmap',
             type: 'tuple[]',
           },
         ],
-        internalType: 'struct IUniswapV3StateMulticall.StateResult',
+        internalType: 'struct UniswapV3StateMulticall.StateResult',
         name: 'state',
         type: 'tuple',
       },

--- a/packages/smart-router/src/liquidity-providers/AlgebraBase.ts
+++ b/packages/smart-router/src/liquidity-providers/AlgebraBase.ts
@@ -17,7 +17,7 @@ interface PoolInfo {
 }
 
 export abstract class AlgebraBaseProvider extends LiquidityProvider {
-  public readonly BIT_AMOUNT = 48
+  public readonly BIT_AMOUNT = 1
   public poolCodes: PoolCode[] = []
 
   public readonly initialPools: Map<string, PoolInfo> = new Map()

--- a/packages/smart-router/src/liquidity-providers/ArthSwapV3.ts
+++ b/packages/smart-router/src/liquidity-providers/ArthSwapV3.ts
@@ -18,7 +18,7 @@ interface PoolInfo {
 
 export class ArthSwapV3Provider extends LiquidityProvider {
   public readonly SWAP_FEES = [0.0001, 0.0005, 0.003, 0.01]
-  public readonly BIT_AMOUNT = 1
+  public readonly BIT_AMOUNT = 0
   public poolCodes: PoolCode[] = []
 
   public readonly initialPools: Map<string, PoolInfo> = new Map()
@@ -30,7 +30,7 @@ export class ArthSwapV3Provider extends LiquidityProvider {
   }
 
   public readonly stateMultiCall: { [chainId: number]: Address } = {
-    [ParachainId.ASTAR]: '0x428013D9043BB6854B3C98494a3E24D6E8fE3BBB',
+    [ParachainId.ASTAR]: '0x6274Fc46Ce9D16A640F6027471515bDcFcc7c75c',
   }
 
   public constructor(chainId: ParachainId, client: PublicClient) {
@@ -62,42 +62,34 @@ export class ArthSwapV3Provider extends LiquidityProvider {
       }
     }
 
-    const poolState = (await Promise.all(
-      [
-        [this.BIT_AMOUNT, -this.BIT_AMOUNT],
-        [0, 0],
-        [-this.BIT_AMOUNT, this.BIT_AMOUNT],
-      ].map(([left, right]) =>
-        this.client
-          .multicall({
-            allowFailure: true,
-            contracts: pools.map(
-              pool =>
-                ({
-                  args: [
-                    this.factory[this.chainId] as Address,
-                    pool.token0.address as Address,
-                    pool.token1.address as Address,
-                    pool.swapFee * 1000000,
-                    left,
-                    right,
-                  ],
-                  address: this.stateMultiCall[this.chainId] as Address,
-                  chainId: chainsParachainIdToChainId[this.chainId],
-                  abi: uniswapV3StateMulticall,
-                  functionName: 'getFullStateWithRelativeBitmaps',
-                } as const),
-            ),
-          }),
-      ),
-    )).flat()
+    const poolState = await this.client
+      .multicall({
+        allowFailure: true,
+        contracts: pools.map(
+          pool =>
+            ({
+              args: [
+                this.factory[this.chainId] as Address,
+                pool.token0.address as Address,
+                pool.token1.address as Address,
+                pool.swapFee * 1000000,
+                this.BIT_AMOUNT,
+                this.BIT_AMOUNT,
+              ],
+              address: this.stateMultiCall[this.chainId] as Address,
+              chainId: chainsParachainIdToChainId[this.chainId],
+              abi: uniswapV3StateMulticall,
+              functionName: 'getFullStateWithRelativeBitmaps',
+            } as const),
+        ),
+      })
 
     const ticksMap = new Map<string, { index: number; value: bigint }[]>()
-    pools.forEach((_, i) => {
-      if (poolState?.[i].status !== 'success' || !poolState?.[i].result)
+    poolState.forEach((state) => {
+      if (state.status !== 'success' || !state.result)
         return
-      const address = poolState[i].result?.pool
-      const tickBitmap = poolState[i].result?.tickBitmap
+      const address = state.result?.pool
+      const tickBitmap = state.result?.tickBitmap
       if (!address || !tickBitmap)
         return
       const tickMap = ticksMap.get(address) || []

--- a/packages/smart-router/src/liquidity-providers/ArthSwapV3.ts
+++ b/packages/smart-router/src/liquidity-providers/ArthSwapV3.ts
@@ -18,7 +18,7 @@ interface PoolInfo {
 
 export class ArthSwapV3Provider extends LiquidityProvider {
   public readonly SWAP_FEES = [0.0001, 0.0005, 0.003, 0.01]
-  public readonly BIT_AMOUNT = 48
+  public readonly BIT_AMOUNT = 1
   public poolCodes: PoolCode[] = []
 
   public readonly initialPools: Map<string, PoolInfo> = new Map()
@@ -30,7 +30,7 @@ export class ArthSwapV3Provider extends LiquidityProvider {
   }
 
   public readonly stateMultiCall: { [chainId: number]: Address } = {
-    [ParachainId.ASTAR]: '0x9080E3941A3404506B4Eada0017C856587A9c916',
+    [ParachainId.ASTAR]: '0x428013D9043BB6854B3C98494a3E24D6E8fE3BBB',
   }
 
   public constructor(chainId: ParachainId, client: PublicClient) {

--- a/packages/smart-router/src/liquidity-providers/ArthSwapV3.ts
+++ b/packages/smart-router/src/liquidity-providers/ArthSwapV3.ts
@@ -30,7 +30,7 @@ export class ArthSwapV3Provider extends LiquidityProvider {
   }
 
   public readonly stateMultiCall: { [chainId: number]: Address } = {
-    [ParachainId.ASTAR]: '0x6274Fc46Ce9D16A640F6027471515bDcFcc7c75c',
+    [ParachainId.ASTAR]: '0x49cBC5EaAd74F36fCA45B704267Ee864B0BE3147',
   }
 
   public constructor(chainId: ParachainId, client: PublicClient) {

--- a/packages/smart-router/src/liquidity-providers/BeamSwapV3.ts
+++ b/packages/smart-router/src/liquidity-providers/BeamSwapV3.ts
@@ -18,7 +18,7 @@ interface PoolInfo {
 
 export class BeamSwapV3Provider extends LiquidityProvider {
   public readonly SWAP_FEES = [0.0001, 0.0005, 0.003, 0.01]
-  public readonly BIT_AMOUNT = 24
+  public readonly BIT_AMOUNT = 1
   public poolCodes: PoolCode[] = []
 
   public readonly initialPools: Map<string, PoolInfo> = new Map()
@@ -30,7 +30,7 @@ export class BeamSwapV3Provider extends LiquidityProvider {
   }
 
   public readonly stateMultiCall: { [chainId: number]: Address } = {
-    [ParachainId.MOONBEAM]: '0x26DFc61329b6a2bBAb2D13f06Ec9B0C5cb2f1ABE',
+    [ParachainId.MOONBEAM]: '0xC94464696676731f182c951946a836f64C552309',
   }
 
   public constructor(chainId: ParachainId, client: PublicClient) {

--- a/packages/smart-router/src/liquidity-providers/BeamSwapV3.ts
+++ b/packages/smart-router/src/liquidity-providers/BeamSwapV3.ts
@@ -30,7 +30,7 @@ export class BeamSwapV3Provider extends LiquidityProvider {
   }
 
   public readonly stateMultiCall: { [chainId: number]: Address } = {
-    [ParachainId.MOONBEAM]: '0x135853E7921ec8D9CAFAaDd4B9B6C04AF7684Cb7',
+    [ParachainId.MOONBEAM]: '0x9927553354aE0442cd234AB6f88582FA6bc84dC2',
   }
 
   public constructor(chainId: ParachainId, client: PublicClient) {

--- a/packages/smart-router/src/liquidity-providers/BeamSwapV3.ts
+++ b/packages/smart-router/src/liquidity-providers/BeamSwapV3.ts
@@ -62,31 +62,48 @@ export class BeamSwapV3Provider extends LiquidityProvider {
       }
     }
 
-    const poolState = await this.client
-      .multicall({
-        allowFailure: true,
-        contracts: pools.map(
-          pool =>
-            ({
-              args: [
-                this.factory[this.chainId] as Address,
-                pool.token0.address as Address,
-                pool.token1.address as Address,
-                pool.swapFee * 1000000,
-                this.BIT_AMOUNT,
-                this.BIT_AMOUNT,
-              ],
-              address: this.stateMultiCall[this.chainId] as Address,
-              chainId: chainsParachainIdToChainId[this.chainId],
-              abi: uniswapV3StateMulticall,
-              functionName: 'getFullStateWithRelativeBitmaps',
-            } as const),
-        ),
-      })
-      .catch((e) => {
-        console.warn(e.message)
-        return undefined
-      })
+    const poolState = (await Promise.all(
+      [
+        [this.BIT_AMOUNT, -this.BIT_AMOUNT],
+        [0, 0],
+        [-this.BIT_AMOUNT, this.BIT_AMOUNT],
+      ].map(([left, right]) =>
+        this.client
+          .multicall({
+            allowFailure: true,
+            contracts: pools.map(
+              pool =>
+                ({
+                  args: [
+                    this.factory[this.chainId] as Address,
+                    pool.token0.address as Address,
+                    pool.token1.address as Address,
+                    pool.swapFee * 1000000,
+                    left,
+                    right,
+                  ],
+                  address: this.stateMultiCall[this.chainId] as Address,
+                  chainId: chainsParachainIdToChainId[this.chainId],
+                  abi: uniswapV3StateMulticall,
+                  functionName: 'getFullStateWithRelativeBitmaps',
+                } as const),
+            ),
+          }),
+      ),
+    )).flat()
+
+    const ticksMap = new Map<string, { index: number; value: bigint }[]>()
+    pools.forEach((_, i) => {
+      if (poolState?.[i].status !== 'success' || !poolState?.[i].result)
+        return
+      const address = poolState[i].result?.pool
+      const tickBitmap = poolState[i].result?.tickBitmap
+      if (!address || !tickBitmap)
+        return
+      const tickMap = ticksMap.get(address) || []
+      tickMap.concat(tickBitmap)
+      ticksMap.set(address, tickMap)
+    })
 
     pools.forEach((pool, i) => {
       if (poolState?.[i].status !== 'success' || !poolState?.[i].result)
@@ -98,7 +115,7 @@ export class BeamSwapV3Provider extends LiquidityProvider {
       const tick = poolState[i].result?.slot0.tick
       const liquidity = poolState[i].result?.liquidity
       const sqrtPriceX96 = poolState[i].result?.slot0.sqrtPriceX96
-      const tickBitmap = poolState[i].result?.tickBitmap
+      const tickBitmap = ticksMap.get(address || '')
 
       if (
         !address
@@ -134,69 +151,6 @@ export class BeamSwapV3Provider extends LiquidityProvider {
     })
   }
 
-  public async updatePoolsData() {
-    if (!this.poolCodes.length)
-      return
-
-    const poolAddr = new Map<string, UniV3Pool>()
-    this.poolCodes.forEach(p => poolAddr.set(p.pool.address, p.pool as UniV3Pool))
-    const pools = Array.from(this.initialPools.values())
-
-    const poolState = await this.client
-      .multicall({
-        multicallAddress: this.client.chain?.contracts?.multicall3?.address as Address,
-        allowFailure: true,
-        contracts: pools.map(
-          pool =>
-            ({
-              args: [
-                this.factory[this.chainId] as Address,
-                pool.token0.address as Address,
-                pool.token1.address as Address,
-                pool.swapFee * 10000,
-                this.BIT_AMOUNT,
-                this.BIT_AMOUNT,
-              ],
-              address: this.stateMultiCall[this.chainId] as Address,
-              chainId: this.chainId,
-              abi: uniswapV3StateMulticall,
-              functionName: 'getFullStateWithRelativeBitmaps',
-            } as const),
-        ),
-      })
-      .catch((e) => {
-        console.warn(`${e.message}`)
-        return undefined
-      })
-
-    pools.forEach((_, i) => {
-      if (poolState?.[i].status !== 'success' || !poolState?.[i].result)
-        return
-
-      const address = poolState[i].result?.pool
-      const balance0 = poolState[i].result?.balance0
-      const balance1 = poolState[i].result?.balance1
-      const tick = poolState[i].result?.slot0.tick
-      const liquidity = poolState[i].result?.liquidity
-      const sqrtPriceX96 = poolState[i].result?.slot0.sqrtPriceX96
-
-      if (!address || !tick || !liquidity || !sqrtPriceX96 || !balance0 || !balance1)
-        return
-
-      const v3pool = poolAddr.get(address)
-      if (v3pool) {
-        v3pool.updateState(
-          BigNumber.from(balance0),
-          BigNumber.from(balance1),
-          tick,
-          BigNumber.from(liquidity),
-          BigNumber.from(sqrtPriceX96),
-        )
-        ++this.stateId
-      }
-    })
-  }
-
   private _getProspectiveTokens(t0: Token, t1: Token): Token[] {
     const set = new Set<Token>([
       t0,
@@ -215,7 +169,6 @@ export class BeamSwapV3Provider extends LiquidityProvider {
     this.unwatchBlockNumber = this.client.watchBlockNumber({
       onBlockNumber: (blockNumber) => {
         this.lastUpdateBlock = Number(blockNumber)
-        this.updatePoolsData()
       },
       onError: (error) => {
         console.error(error.message)

--- a/packages/smart-router/src/liquidity-providers/KyperElastic.ts
+++ b/packages/smart-router/src/liquidity-providers/KyperElastic.ts
@@ -62,31 +62,48 @@ export class KyperElasticProvider extends LiquidityProvider {
       }
     }
 
-    const poolState = await this.client
-      .multicall({
-        allowFailure: true,
-        contracts: pools.map(
-          pool =>
-            ({
-              args: [
-                this.factory[this.chainId] as Address,
-                pool.token0.address as Address,
-                pool.token1.address as Address,
-                pool.swapFee * 100000,
-                this.BIT_AMOUNT,
-                this.BIT_AMOUNT,
-              ],
-              address: this.stateMultiCall[this.chainId] as Address,
-              chainId: chainsParachainIdToChainId[this.chainId],
-              abi: kyperElasticStateMulticall,
-              functionName: 'getFullStateWithRelativeBitmaps',
-            } as const),
-        ),
-      })
-      .catch((e) => {
-        console.warn(e.message)
-        return undefined
-      })
+    const poolState = (await Promise.all(
+      [
+        [this.BIT_AMOUNT, -this.BIT_AMOUNT],
+        [0, 0],
+        [-this.BIT_AMOUNT, this.BIT_AMOUNT],
+      ].map(([left, right]) =>
+        this.client
+          .multicall({
+            allowFailure: true,
+            contracts: pools.map(
+              pool =>
+                ({
+                  args: [
+                    this.factory[this.chainId] as Address,
+                    pool.token0.address as Address,
+                    pool.token1.address as Address,
+                    pool.swapFee * 100000,
+                    left,
+                    right,
+                  ],
+                  address: this.stateMultiCall[this.chainId] as Address,
+                  chainId: chainsParachainIdToChainId[this.chainId],
+                  abi: kyperElasticStateMulticall,
+                  functionName: 'getFullStateWithRelativeBitmaps',
+                } as const),
+            ),
+          }),
+      ),
+    )).flat()
+
+    const ticksMap = new Map<string, { tick: number; liquidityNet: bigint }[]>()
+    pools.forEach((_, i) => {
+      if (poolState?.[i].status !== 'success' || !poolState?.[i].result)
+        return
+      const address = poolState[i].result?.pool
+      const tickBitmap = poolState[i].result?.ticks
+      if (!address || !tickBitmap)
+        return
+      const tickMap = ticksMap.get(address) || []
+      tickMap.concat(tickBitmap)
+      ticksMap.set(address, tickMap)
+    })
 
     pools.forEach((pool, i) => {
       if (poolState?.[i].status !== 'success' || !poolState?.[i].result)
@@ -97,7 +114,7 @@ export class KyperElasticProvider extends LiquidityProvider {
       const tick = poolState[i].result?.currentTick
       const liquidity = poolState[i].result?.baseL
       const sqrtPriceX96 = poolState[i].result?.sqrtP
-      const tickBitmap = poolState[i].result?.ticks
+      const tickBitmap = ticksMap.get(address || '')
 
       if (
         !address

--- a/packages/smart-router/src/liquidity-providers/StellaSwapV3.ts
+++ b/packages/smart-router/src/liquidity-providers/StellaSwapV3.ts
@@ -10,7 +10,7 @@ export class StellaSwapV3Provider extends AlgebraBaseProvider {
       [ParachainId.MOONBEAM]: '0xabE1655110112D0E45EF91e94f8d757e4ddBA59C',
     } as const
     const stateMultiCall = {
-      [ParachainId.MOONBEAM]: '0x09c58401cfb944405c67326908F056874300a50b',
+      [ParachainId.MOONBEAM]: '0xed4777785e3021f61b391C01c56361e790fd8b19',
     } as const
 
     super(chainId, client, factory, stateMultiCall)

--- a/packages/smart-router/src/liquidity-providers/StellaSwapV3.ts
+++ b/packages/smart-router/src/liquidity-providers/StellaSwapV3.ts
@@ -10,7 +10,7 @@ export class StellaSwapV3Provider extends AlgebraBaseProvider {
       [ParachainId.MOONBEAM]: '0xabE1655110112D0E45EF91e94f8d757e4ddBA59C',
     } as const
     const stateMultiCall = {
-      [ParachainId.MOONBEAM]: '0x68610A32D87197b6aFc48324dc6Ba4222B354165',
+      [ParachainId.MOONBEAM]: '0xf962d4deA2F21eB35E688686370698720FED9afb',
     } as const
 
     super(chainId, client, factory, stateMultiCall)

--- a/packages/smart-router/src/liquidity-providers/StellaSwapV3.ts
+++ b/packages/smart-router/src/liquidity-providers/StellaSwapV3.ts
@@ -10,7 +10,7 @@ export class StellaSwapV3Provider extends AlgebraBaseProvider {
       [ParachainId.MOONBEAM]: '0xabE1655110112D0E45EF91e94f8d757e4ddBA59C',
     } as const
     const stateMultiCall = {
-      [ParachainId.MOONBEAM]: '0xf962d4deA2F21eB35E688686370698720FED9afb',
+      [ParachainId.MOONBEAM]: '0x09c58401cfb944405c67326908F056874300a50b',
     } as const
 
     super(chainId, client, factory, stateMultiCall)

--- a/packages/smart-router/src/liquidity-providers/SushiV3.ts
+++ b/packages/smart-router/src/liquidity-providers/SushiV3.ts
@@ -10,7 +10,7 @@ export class SushiV3Provider extends UniswapV3BaseProvider {
       [ParachainId.BASE]: '0xc35DADB65012eC5796536bD9864eD8773aBc74C4',
     } as const
     const stateMultiCall = {
-      [ParachainId.BASE]: '0x87b7881128172F92964D9fa61D77cBa6B132873F',
+      [ParachainId.BASE]: '0x7e6af010fE9a0afe090Ff2ee21e0a094C8A45370',
     } as const
 
     super(chainId, client, factory, stateMultiCall)

--- a/packages/smart-router/src/liquidity-providers/SushiV3.ts
+++ b/packages/smart-router/src/liquidity-providers/SushiV3.ts
@@ -10,7 +10,7 @@ export class SushiV3Provider extends UniswapV3BaseProvider {
       [ParachainId.BASE]: '0xc35DADB65012eC5796536bD9864eD8773aBc74C4',
     } as const
     const stateMultiCall = {
-      [ParachainId.BASE]: '0xbecE3Ff54D129542d28a8aD10DC7C24aB3A0aFAa',
+      [ParachainId.BASE]: '0x40792858b91D7543A2404936ffbD74CE3900aa6E',
     } as const
 
     super(chainId, client, factory, stateMultiCall)

--- a/packages/smart-router/src/liquidity-providers/SushiV3.ts
+++ b/packages/smart-router/src/liquidity-providers/SushiV3.ts
@@ -10,7 +10,7 @@ export class SushiV3Provider extends UniswapV3BaseProvider {
       [ParachainId.BASE]: '0xc35DADB65012eC5796536bD9864eD8773aBc74C4',
     } as const
     const stateMultiCall = {
-      [ParachainId.BASE]: '0x7e6af010fE9a0afe090Ff2ee21e0a094C8A45370',
+      [ParachainId.BASE]: '0xbecE3Ff54D129542d28a8aD10DC7C24aB3A0aFAa',
     } as const
 
     super(chainId, client, factory, stateMultiCall)

--- a/packages/smart-router/src/liquidity-providers/UniswapV3.ts
+++ b/packages/smart-router/src/liquidity-providers/UniswapV3.ts
@@ -16,7 +16,7 @@ export class UniswapV3Provider extends UniswapV3BaseProvider {
       [ParachainId.ARBITRUM_ONE]: '0x4095d49863190Ab7f80EF5c86b0fC988dEF75C84',
       [ParachainId.SCROLL_ALPHA]: '0xAFCCA0f68e0883b797c71525377DE46B2E65AB28',
       [ParachainId.BASE]: '0xbecE3Ff54D129542d28a8aD10DC7C24aB3A0aFAa',
-      [ParachainId.MOONBEAM]: '0x135853E7921ec8D9CAFAaDd4B9B6C04AF7684Cb7',
+      [ParachainId.MOONBEAM]: '0x9927553354aE0442cd234AB6f88582FA6bc84dC2',
     } as const
 
     super(chainId, client, factory, stateMultiCall)

--- a/packages/smart-router/src/liquidity-providers/UniswapV3.ts
+++ b/packages/smart-router/src/liquidity-providers/UniswapV3.ts
@@ -13,10 +13,10 @@ export class UniswapV3Provider extends UniswapV3BaseProvider {
       [ParachainId.MOONBEAM]: '0x28f1158795A3585CaAA3cD6469CD65382b89BB70',
     } as const
     const stateMultiCall = {
-      [ParachainId.ARBITRUM_ONE]: '0x7B1128E610ae1d461B7B8227f9FBBB39e336c515',
+      [ParachainId.ARBITRUM_ONE]: '0x5c30e38BEb6A2F3d36bBeC64f32259436e7DcecC',
       [ParachainId.SCROLL_ALPHA]: '0xAFCCA0f68e0883b797c71525377DE46B2E65AB28',
-      [ParachainId.BASE]: '0x87b7881128172F92964D9fa61D77cBa6B132873F',
-      [ParachainId.MOONBEAM]: '0x26DFc61329b6a2bBAb2D13f06Ec9B0C5cb2f1ABE',
+      [ParachainId.BASE]: '0x7e6af010fE9a0afe090Ff2ee21e0a094C8A45370',
+      [ParachainId.MOONBEAM]: '0xC94464696676731f182c951946a836f64C552309',
     } as const
 
     super(chainId, client, factory, stateMultiCall)

--- a/packages/smart-router/src/liquidity-providers/UniswapV3.ts
+++ b/packages/smart-router/src/liquidity-providers/UniswapV3.ts
@@ -13,9 +13,9 @@ export class UniswapV3Provider extends UniswapV3BaseProvider {
       [ParachainId.MOONBEAM]: '0x28f1158795A3585CaAA3cD6469CD65382b89BB70',
     } as const
     const stateMultiCall = {
-      [ParachainId.ARBITRUM_ONE]: '0x4095d49863190Ab7f80EF5c86b0fC988dEF75C84',
+      [ParachainId.ARBITRUM_ONE]: '0x653aE5790B133d4f42F344104eeC47795a6C2388',
       [ParachainId.SCROLL_ALPHA]: '0xAFCCA0f68e0883b797c71525377DE46B2E65AB28',
-      [ParachainId.BASE]: '0xbecE3Ff54D129542d28a8aD10DC7C24aB3A0aFAa',
+      [ParachainId.BASE]: '0x40792858b91D7543A2404936ffbD74CE3900aa6E',
       [ParachainId.MOONBEAM]: '0x9927553354aE0442cd234AB6f88582FA6bc84dC2',
     } as const
 

--- a/packages/smart-router/src/liquidity-providers/UniswapV3.ts
+++ b/packages/smart-router/src/liquidity-providers/UniswapV3.ts
@@ -13,10 +13,10 @@ export class UniswapV3Provider extends UniswapV3BaseProvider {
       [ParachainId.MOONBEAM]: '0x28f1158795A3585CaAA3cD6469CD65382b89BB70',
     } as const
     const stateMultiCall = {
-      [ParachainId.ARBITRUM_ONE]: '0x5c30e38BEb6A2F3d36bBeC64f32259436e7DcecC',
+      [ParachainId.ARBITRUM_ONE]: '0x4095d49863190Ab7f80EF5c86b0fC988dEF75C84',
       [ParachainId.SCROLL_ALPHA]: '0xAFCCA0f68e0883b797c71525377DE46B2E65AB28',
-      [ParachainId.BASE]: '0x7e6af010fE9a0afe090Ff2ee21e0a094C8A45370',
-      [ParachainId.MOONBEAM]: '0xC94464696676731f182c951946a836f64C552309',
+      [ParachainId.BASE]: '0xbecE3Ff54D129542d28a8aD10DC7C24aB3A0aFAa',
+      [ParachainId.MOONBEAM]: '0x135853E7921ec8D9CAFAaDd4B9B6C04AF7684Cb7',
     } as const
 
     super(chainId, client, factory, stateMultiCall)

--- a/packages/smart-router/src/liquidity-providers/UniswapV3Base.ts
+++ b/packages/smart-router/src/liquidity-providers/UniswapV3Base.ts
@@ -25,7 +25,7 @@ interface SameTokensPoolInfo {
 
 export abstract class UniswapV3BaseProvider extends LiquidityProvider {
   public readonly SWAP_FEES = [0.0001, 0.0005, 0.003, 0.01]
-  public readonly BIT_AMOUNT = 48
+  public readonly BIT_AMOUNT = 1
   public poolCodes: PoolCode[] = []
 
   public readonly initialPools: Map<string, PoolInfo> = new Map()

--- a/packages/smart-router/src/liquidity-providers/UniswapV3Base.ts
+++ b/packages/smart-router/src/liquidity-providers/UniswapV3Base.ts
@@ -8,7 +8,7 @@ import { ADDITIONAL_BASES, BASES_TO_CHECK_TRADES_AGAINST } from '@zenlink-interf
 import type { PoolCode, UniV3Tick } from '../entities'
 import { UniV3Pool, UniV3PoolCode } from '../entities'
 import { uniswapV3StateMulticall } from '../abis/uniswapV3StateMulticall'
-import { closeValues, formatAddress, getNumber } from '../util'
+import { formatAddress } from '../util'
 import { LiquidityProvider } from './LiquidityProvider'
 
 interface PoolInfo {
@@ -71,33 +71,48 @@ export abstract class UniswapV3BaseProvider extends LiquidityProvider {
       }
     }
 
-    const poolState = await this.client
-      .multicall({
-        allowFailure: true,
-        contracts: pools.map(
-          pool =>
-            ({
-              args: [
-                this.factory[this.chainId] as Address,
-                pool.token0.address as Address,
-                pool.token1.address as Address,
-                pool.swapFee * 1000000,
-                this.BIT_AMOUNT,
-                this.BIT_AMOUNT,
-              ],
-              address: this.stateMultiCall[this.chainId] as Address,
-              chainId: chainsParachainIdToChainId[this.chainId],
-              abi: uniswapV3StateMulticall,
-              functionName: 'getFullStateWithRelativeBitmaps',
-            } as const),
-        ),
-      })
-      .catch((e) => {
-        console.warn(e.message)
-        return undefined
-      })
+    const poolState = (await Promise.all(
+      [
+        [this.BIT_AMOUNT, -this.BIT_AMOUNT],
+        [0, 0],
+        [-this.BIT_AMOUNT, this.BIT_AMOUNT],
+      ].map(([left, right]) =>
+        this.client
+          .multicall({
+            allowFailure: true,
+            contracts: pools.map(
+              pool =>
+                ({
+                  args: [
+                    this.factory[this.chainId] as Address,
+                    pool.token0.address as Address,
+                    pool.token1.address as Address,
+                    pool.swapFee * 1000000,
+                    left,
+                    right,
+                  ],
+                  address: this.stateMultiCall[this.chainId] as Address,
+                  chainId: chainsParachainIdToChainId[this.chainId],
+                  abi: uniswapV3StateMulticall,
+                  functionName: 'getFullStateWithRelativeBitmaps',
+                } as const),
+            ),
+          }),
+      ),
+    )).flat()
 
-    const sameTokensPoolInfos = new Map<string, SameTokensPoolInfo>()
+    const ticksMap = new Map<string, { index: number; value: bigint }[]>()
+    pools.forEach((_, i) => {
+      if (poolState?.[i].status !== 'success' || !poolState?.[i].result)
+        return
+      const address = poolState[i].result?.pool
+      const tickBitmap = poolState[i].result?.tickBitmap
+      if (!address || !tickBitmap)
+        return
+      const tickMap = ticksMap.get(address) || []
+      tickMap.concat(tickBitmap)
+      ticksMap.set(address, tickMap)
+    })
 
     pools.forEach((pool, i) => {
       if (poolState?.[i].status !== 'success' || !poolState?.[i].result)
@@ -109,7 +124,7 @@ export abstract class UniswapV3BaseProvider extends LiquidityProvider {
       const tick = poolState[i].result?.slot0.tick
       const liquidity = poolState[i].result?.liquidity
       const sqrtPriceX96 = poolState[i].result?.slot0.sqrtPriceX96
-      const tickBitmap = poolState[i].result?.tickBitmap
+      const tickBitmap = ticksMap.get(address || '')
 
       if (
         !address
@@ -139,49 +154,10 @@ export abstract class UniswapV3BaseProvider extends LiquidityProvider {
         ticks,
       )
 
-      const poolKey = `${pool.token0.address}-${pool.token1.address}`
-      let sameTokensPoolInfo = sameTokensPoolInfos.get(poolKey)
-
-      if (!sameTokensPoolInfo) {
-        sameTokensPoolInfo = {
-          topLiquidity: liquidity,
-          sqrtPriceX96,
-          pools: [v3pool],
-        }
-        sameTokensPoolInfos.set(poolKey, sameTokensPoolInfo)
-      }
-      else {
-        if (liquidity > sameTokensPoolInfo.topLiquidity) {
-          sameTokensPoolInfo.topLiquidity = liquidity
-          sameTokensPoolInfo.sqrtPriceX96 = sqrtPriceX96
-          const poolsCache = [...sameTokensPoolInfo.pools]
-          sameTokensPoolInfo.pools.forEach((pool, i) => {
-            if (
-              !closeValues(getNumber(pool.sqrtPriceX96), getNumber(sqrtPriceX96), 0.1)
-              || !closeValues(getNumber(pool.liquidity), getNumber(liquidity), 0.01)
-            )
-              poolsCache.splice(i, 1)
-          })
-          poolsCache.push(v3pool)
-          sameTokensPoolInfo.pools = poolsCache
-        }
-        else {
-          if (
-            closeValues(getNumber(sameTokensPoolInfo.sqrtPriceX96), getNumber(sqrtPriceX96), 0.1)
-            && closeValues(getNumber(sameTokensPoolInfo.topLiquidity), getNumber(liquidity), 0.01)
-          )
-            sameTokensPoolInfo.pools.push(v3pool)
-        }
-        sameTokensPoolInfos.set(poolKey, sameTokensPoolInfo)
-      }
-    })
-
-    Array.from(sameTokensPoolInfos.values()).forEach((sameTokensPoolInfo) => {
-      sameTokensPoolInfo.pools.forEach((pool) => {
-        const pc = new UniV3PoolCode(pool, this.getPoolProviderName())
-        this.poolCodes.push(pc)
-        ++this.stateId
-      })
+      const pc = new UniV3PoolCode(v3pool, this.getPoolProviderName())
+      this.initialPools.set(address, pool)
+      this.poolCodes.push(pc)
+      ++this.stateId
     })
   }
 

--- a/packages/smart-router/src/liquidity-providers/UniswapV3Base.ts
+++ b/packages/smart-router/src/liquidity-providers/UniswapV3Base.ts
@@ -25,7 +25,7 @@ interface SameTokensPoolInfo {
 
 export abstract class UniswapV3BaseProvider extends LiquidityProvider {
   public readonly SWAP_FEES = [0.0001, 0.0005, 0.003, 0.01]
-  public readonly BIT_AMOUNT = 1
+  public readonly BIT_AMOUNT = 0
   public poolCodes: PoolCode[] = []
 
   public readonly initialPools: Map<string, PoolInfo> = new Map()
@@ -71,42 +71,34 @@ export abstract class UniswapV3BaseProvider extends LiquidityProvider {
       }
     }
 
-    const poolState = (await Promise.all(
-      [
-        [this.BIT_AMOUNT, -this.BIT_AMOUNT],
-        [0, 0],
-        [-this.BIT_AMOUNT, this.BIT_AMOUNT],
-      ].map(([left, right]) =>
-        this.client
-          .multicall({
-            allowFailure: true,
-            contracts: pools.map(
-              pool =>
-                ({
-                  args: [
-                    this.factory[this.chainId] as Address,
-                    pool.token0.address as Address,
-                    pool.token1.address as Address,
-                    pool.swapFee * 1000000,
-                    left,
-                    right,
-                  ],
-                  address: this.stateMultiCall[this.chainId] as Address,
-                  chainId: chainsParachainIdToChainId[this.chainId],
-                  abi: uniswapV3StateMulticall,
-                  functionName: 'getFullStateWithRelativeBitmaps',
-                } as const),
-            ),
-          }),
-      ),
-    )).flat()
+    const poolState = await this.client
+      .multicall({
+        allowFailure: true,
+        contracts: pools.map(
+          pool =>
+            ({
+              args: [
+                this.factory[this.chainId] as Address,
+                pool.token0.address as Address,
+                pool.token1.address as Address,
+                pool.swapFee * 1000000,
+                this.BIT_AMOUNT,
+                this.BIT_AMOUNT,
+              ],
+              address: this.stateMultiCall[this.chainId] as Address,
+              chainId: chainsParachainIdToChainId[this.chainId],
+              abi: uniswapV3StateMulticall,
+              functionName: 'getFullStateWithRelativeBitmaps',
+            } as const),
+        ),
+      })
 
     const ticksMap = new Map<string, { index: number; value: bigint }[]>()
-    pools.forEach((_, i) => {
-      if (poolState?.[i].status !== 'success' || !poolState?.[i].result)
+    poolState.forEach((state) => {
+      if (state.status !== 'success' || !state.result)
         return
-      const address = poolState[i].result?.pool
-      const tickBitmap = poolState[i].result?.tickBitmap
+      const address = state.result?.pool
+      const tickBitmap = state.result?.tickBitmap
       if (!address || !tickBitmap)
         return
       const tickMap = ticksMap.get(address) || []

--- a/packages/smart-router/src/liquidity-providers/ZyberSwapV3.ts
+++ b/packages/smart-router/src/liquidity-providers/ZyberSwapV3.ts
@@ -10,7 +10,7 @@ export class ZyberSwapV3Provider extends AlgebraBaseProvider {
       [ParachainId.ARBITRUM_ONE]: '0x9C2ABD632771b433E5E7507BcaA41cA3b25D8544',
     } as const
     const stateMultiCall = {
-      [ParachainId.ARBITRUM_ONE]: '0xf6EA707CBf38f2Acf3bf029429B55192c61c67ad',
+      [ParachainId.ARBITRUM_ONE]: '0x3EB05d24f126B581d2335469C0eCF4995d191E21',
     } as const
 
     super(chainId, client, factory, stateMultiCall)

--- a/packages/smart-router/src/liquidity-providers/ZyberSwapV3.ts
+++ b/packages/smart-router/src/liquidity-providers/ZyberSwapV3.ts
@@ -10,7 +10,7 @@ export class ZyberSwapV3Provider extends AlgebraBaseProvider {
       [ParachainId.ARBITRUM_ONE]: '0x9C2ABD632771b433E5E7507BcaA41cA3b25D8544',
     } as const
     const stateMultiCall = {
-      [ParachainId.ARBITRUM_ONE]: '0xE4721e71Dd9c2995c23cc67CB5a201cE3e5588F7',
+      [ParachainId.ARBITRUM_ONE]: '0x41ed2463Fad6B7521F1FA651E5A1Eb47F41b626E',
     } as const
 
     super(chainId, client, factory, stateMultiCall)

--- a/packages/smart-router/src/liquidity-providers/ZyberSwapV3.ts
+++ b/packages/smart-router/src/liquidity-providers/ZyberSwapV3.ts
@@ -10,7 +10,7 @@ export class ZyberSwapV3Provider extends AlgebraBaseProvider {
       [ParachainId.ARBITRUM_ONE]: '0x9C2ABD632771b433E5E7507BcaA41cA3b25D8544',
     } as const
     const stateMultiCall = {
-      [ParachainId.ARBITRUM_ONE]: '0x3EB05d24f126B581d2335469C0eCF4995d191E21',
+      [ParachainId.ARBITRUM_ONE]: '0xE4721e71Dd9c2995c23cc67CB5a201cE3e5588F7',
     } as const
 
     super(chainId, client, factory, stateMultiCall)


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on updating the liquidity provider addresses for different chains. 

### Detailed summary:
- Updated SushiV3 liquidity provider address for ParachainId.BASE
- Updated StellaSwapV3 liquidity provider address for ParachainId.MOONBEAM
- Updated ZyberSwapV3 liquidity provider address for ParachainId.ARBITRUM_ONE
- Updated UniswapV3 liquidity provider addresses for ParachainId.ARBITRUM_ONE, ParachainId.SCROLL_ALPHA, ParachainId.BASE, and ParachainId.MOONBEAM
- Updated ArthSwapV3 liquidity provider address for ParachainId.ASTAR
- Updated KyperElasticProvider liquidity provider address for ParachainId.SCROLL

> The following files were skipped due to too many changes: `packages/smart-router/src/liquidity-providers/UniswapV3Base.ts`, `packages/smart-router/src/liquidity-providers/AlgebraBase.ts`, `packages/smart-router/src/liquidity-providers/BeamSwapV3.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->