### PR TITLE
fix(ui): roll back headlessui to v1.7.17

### DIFF
--- a/apps/analytics/package.json
+++ b/apps/analytics/package.json
@@ -18,7 +18,7 @@
     "@ethersproject/experimental": "^5.7.0",
     "@ethersproject/providers": "^5.7.2",
     "@ethersproject/solidity": "^5.7.0",
-    "@headlessui/react": "^1.7.18",
+    "@headlessui/react": "1.7.17",
     "@heroicons/react": "2.0.17",
     "@lingui/core": "4.7.0",
     "@lingui/macro": "4.7.0",

--- a/apps/pool/package.json
+++ b/apps/pool/package.json
@@ -18,7 +18,7 @@
     "@ethersproject/experimental": "^5.7.0",
     "@ethersproject/providers": "^5.7.2",
     "@ethersproject/solidity": "^5.7.0",
-    "@headlessui/react": "^1.7.18",
+    "@headlessui/react": "1.7.17",
     "@heroicons/react": "2.0.17",
     "@lingui/core": "4.7.0",
     "@lingui/macro": "4.7.0",

--- a/apps/referrals/package.json
+++ b/apps/referrals/package.json
@@ -12,7 +12,7 @@
     "@ethersproject/address": "^5.7.0",
     "@ethersproject/constants": "^5.7.0",
     "@ethersproject/providers": "^5.7.2",
-    "@headlessui/react": "^1.7.18",
+    "@headlessui/react": "1.7.17",
     "@heroicons/react": "2.0.17",
     "@lingui/core": "4.7.0",
     "@lingui/macro": "4.7.0",

--- a/apps/swap/package.json
+++ b/apps/swap/package.json
@@ -12,7 +12,7 @@
     "@ethersproject/address": "^5.7.0",
     "@ethersproject/constants": "^5.7.0",
     "@ethersproject/providers": "^5.7.2",
-    "@headlessui/react": "^1.7.18",
+    "@headlessui/react": "1.7.17",
     "@heroicons/react": "2.0.17",
     "@lingui/core": "4.7.0",
     "@lingui/macro": "4.7.0",

--- a/packages/compat/package.json
+++ b/packages/compat/package.json
@@ -24,7 +24,7 @@
   },
   "dependencies": {
     "@ethersproject/constants": "^5.7.0",
-    "@headlessui/react": "^1.7.18",
+    "@headlessui/react": "1.7.17",
     "@heroicons/react": "2.0.17",
     "@lingui/core": "4.7.0",
     "@lingui/macro": "4.7.0",

--- a/packages/parachains-impl/amplitude/package.json
+++ b/packages/parachains-impl/amplitude/package.json
@@ -22,7 +22,7 @@
     "react-dom": "^18.2.0"
   },
   "dependencies": {
-    "@headlessui/react": "^1.7.18",
+    "@headlessui/react": "1.7.17",
     "@heroicons/react": "^2.0.17",
     "@lingui/core": "^4.7.0",
     "@lingui/macro": "4.7.0",

--- a/packages/parachains-impl/bifrost/package.json
+++ b/packages/parachains-impl/bifrost/package.json
@@ -21,7 +21,7 @@
     "react-dom": "^18.2.0"
   },
   "dependencies": {
-    "@headlessui/react": "^1.7.18",
+    "@headlessui/react": "1.7.17",
     "@heroicons/react": "2.0.17",
     "@lingui/core": "4.7.0",
     "@lingui/macro": "4.7.0",

--- a/packages/ui/animation/AppearOnMount/AppearOnMount.tsx
+++ b/packages/ui/animation/AppearOnMount/AppearOnMount.tsx
@@ -19,16 +19,16 @@ export const AppearOnMount: FC<AppearOnMountProps> = ({ as = 'div', show, childr
   if (isMounted) {
     return (
       <Transition
-        as={as}
         appear
+        as={as}
         className={className}
-        show={show !== undefined ? show : true}
         enter="transition duration-300 origin-center ease-out"
         enterFrom="transform scale-90 opacity-0"
         enterTo="transform scale-100 opacity-100"
         leave="transition duration-75 ease-out"
         leaveFrom="transform opacity-100"
         leaveTo="transform opacity-0"
+        show={show !== undefined ? show : true}
       >
         {typeof children === 'function' ? children(isMounted) : children}
       </Transition>

--- a/packages/ui/animation/SlideIn/FromBottom.tsx
+++ b/packages/ui/animation/SlideIn/FromBottom.tsx
@@ -39,14 +39,14 @@ export const FromBottom: FC<FromBottomProps> = ({
 
   if (isSmallScreen) {
     return (
-      <Dialog open={show} onClose={onClose} unmount={false} initialFocus={undefined}>
+      <Dialog initialFocus={undefined} onClose={onClose} open={show} unmount={false}>
         <div className="!rounded-t-2xl overflow-hidden">{children}</div>
       </Dialog>
     )
   }
 
   return ReactDOM.createPortal(
-    <Transition.Root appear show={show} unmount={false} as={Fragment}>
+    <Transition.Root appear as={Fragment} show={show} unmount={false}>
       <div className={classNames(className, 'absolute left-0 right-0 bottom-0 h-full translate-y-[100%] z-50')}>
         <Transition.Child
           as={Fragment}
@@ -60,22 +60,22 @@ export const FromBottom: FC<FromBottomProps> = ({
         >
           <div
             aria-hidden="true"
-            onClick={onClose}
             className="translate-y-[-100%] absolute inset-0 bg-black/70 transition-opacity"
+            onClick={onClose}
           />
         </Transition.Child>
         <Transition.Child
+          afterEnter={afterEnter}
+          afterLeave={afterLeave}
+          as={Fragment}
+          beforeEnter={beforeEnter}
+          beforeLeave={beforeLeave}
           enter="transform transition ease-in-out duration-300"
           enterFrom="translate-y-0"
           enterTo="translate-y-[-100%]"
           leave="transform transition ease-in-out duration-500"
           leaveFrom="translate-y-[-100%]"
           leaveTo="translate-y-0"
-          as={Fragment}
-          afterLeave={afterLeave}
-          afterEnter={afterEnter}
-          beforeEnter={beforeEnter}
-          beforeLeave={beforeLeave}
           unmount={false}
         >
           {children}

--- a/packages/ui/animation/SlideIn/FromLeft.tsx
+++ b/packages/ui/animation/SlideIn/FromLeft.tsx
@@ -39,14 +39,14 @@ export const FromLeft: FC<FromLeftProps> = ({
 
   if (isSmallScreen) {
     return (
-      <Dialog open={show} onClose={onClose} unmount={false} initialFocus={undefined}>
+      <Dialog initialFocus={undefined} onClose={onClose} open={show} unmount={false}>
         <div className="!rounded-t-2xl overflow-hidden">{children}</div>
       </Dialog>
     )
   }
 
   return ReactDOM.createPortal(
-    <Transition.Root appear show={show} unmount={false} as={Fragment}>
+    <Transition.Root appear as={Fragment} show={show} unmount={false}>
       <div className={classNames(className, 'absolute left-0 top-0 bottom-0 w-full translate-x-[-100%] z-[50]')}>
         <Transition.Child
           as={Fragment}
@@ -60,22 +60,22 @@ export const FromLeft: FC<FromLeftProps> = ({
         >
           <div
             aria-hidden="true"
-            onClick={onClose}
             className="translate-x-full absolute inset-0 bg-black/70 transition-opacity"
+            onClick={onClose}
           />
         </Transition.Child>
         <Transition.Child
+          afterEnter={afterEnter}
+          afterLeave={afterLeave}
+          as={Fragment}
+          beforeEnter={beforeEnter}
+          beforeLeave={beforeLeave}
           enter="transform transition ease-in-out duration-300"
           enterFrom="translate-x-0"
           enterTo="translate-x-full"
           leave="transform transition ease-in-out duration-500"
           leaveFrom="translate-x-full"
           leaveTo="translate-x-0"
-          as={Fragment}
-          afterLeave={afterLeave}
-          afterEnter={afterEnter}
-          beforeEnter={beforeEnter}
-          beforeLeave={beforeLeave}
           unmount={false}
         >
           {children}

--- a/packages/ui/animation/SlideIn/FromRight.tsx
+++ b/packages/ui/animation/SlideIn/FromRight.tsx
@@ -39,14 +39,14 @@ export const FromRight: FC<FromRightProps> = ({
 
   if (isSmallScreen) {
     return (
-      <Dialog open={show} onClose={onClose} unmount={false} initialFocus={undefined}>
+      <Dialog initialFocus={undefined} onClose={onClose} open={show} unmount={false}>
         <div className="!rounded-t-2xl overflow-hidden">{children}</div>
       </Dialog>
     )
   }
 
   return ReactDOM.createPortal(
-    <Transition.Root appear show={show} unmount={false} as={Fragment}>
+    <Transition.Root appear as={Fragment} show={show} unmount={false}>
       <div className={classNames(className, 'absolute right-0 top-0 bottom-0 w-full translate-x-[100%] z-50')}>
         <Transition.Child
           as={Fragment}
@@ -60,22 +60,22 @@ export const FromRight: FC<FromRightProps> = ({
         >
           <div
             aria-hidden="true"
-            onClick={onClose}
             className="translate-x-[-100%] absolute inset-0 bg-black/70 transition-opacity"
+            onClick={onClose}
           />
         </Transition.Child>
         <Transition.Child
+          afterEnter={afterEnter}
+          afterLeave={afterLeave}
+          as={Fragment}
+          beforeEnter={beforeEnter}
+          beforeLeave={beforeLeave}
           enter="transform transition ease-in-out duration-300"
           enterFrom="translate-x-0"
           enterTo="translate-x-[-100%]"
           leave="transform transition ease-in-out duration-500"
           leaveFrom="translate-x-[-100%]"
           leaveTo="translate-x-0"
-          as={Fragment}
-          afterLeave={afterLeave}
-          afterEnter={afterEnter}
-          beforeEnter={beforeEnter}
-          beforeLeave={beforeLeave}
           unmount={false}
         >
           {children}

--- a/packages/ui/animation/SlideIn/FromTop.tsx
+++ b/packages/ui/animation/SlideIn/FromTop.tsx
@@ -39,14 +39,14 @@ export const FromTop: FC<FromTopProps> = ({
 
   if (isSmallScreen) {
     return (
-      <Dialog open={show} onClose={onClose} unmount={false} initialFocus={undefined}>
+      <Dialog initialFocus={undefined} onClose={onClose} open={show} unmount={false}>
         <div className="!rounded-t-2xl overflow-hidden">{children}</div>
       </Dialog>
     )
   }
 
   return ReactDOM.createPortal(
-    <Transition.Root appear show={show} unmount={false} as={Fragment}>
+    <Transition.Root appear as={Fragment} show={show} unmount={false}>
       <div className={classNames(className, 'absolute left-0 right-0 top-0 h-full translate-y-[-100%] z-50')}>
         <Transition.Child
           as={Fragment}
@@ -60,22 +60,22 @@ export const FromTop: FC<FromTopProps> = ({
         >
           <div
             aria-hidden="true"
-            onClick={onClose}
             className="translate-y-full absolute inset-0 bg-black/70 transition-opacity"
+            onClick={onClose}
           />
         </Transition.Child>
         <Transition.Child
+          afterEnter={afterEnter}
+          afterLeave={afterLeave}
+          as={Fragment}
+          beforeEnter={beforeEnter}
+          beforeLeave={beforeLeave}
           enter="transform transition ease-in-out duration-300"
           enterFrom="translate-y-0"
           enterTo="translate-y-full"
           leave="transform transition ease-in-out duration-500"
           leaveFrom="translate-y-full"
           leaveTo="translate-y-0"
-          as={Fragment}
-          afterLeave={afterLeave}
-          afterEnter={afterEnter}
-          beforeEnter={beforeEnter}
-          beforeLeave={beforeLeave}
           unmount={false}
         >
           {children}

--- a/packages/ui/animation/SlideIn/SlideIn.tsx
+++ b/packages/ui/animation/SlideIn/SlideIn.tsx
@@ -29,7 +29,7 @@ export const Root: FC<RootProps> = ({ children }) => {
   )
 }
 
-export const useSlideInContext = () => {
+export function useSlideInContext() {
   return useContext(SlideInContext)
 }
 

--- a/packages/ui/animation/SlideIn/useEscapeClose.ts
+++ b/packages/ui/animation/SlideIn/useEscapeClose.ts
@@ -11,5 +11,5 @@ export const useEscapeClose: UseEscapeClose = (cb) => {
 
     document.addEventListener('keydown', handleEscapeKey)
     return () => document.removeEventListener('keydown', handleEscapeKey)
-  }, [])
+  }, [cb])
 }

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -25,7 +25,7 @@
   "dependencies": {
     "@floating-ui/react": "^0.26.5",
     "@fontsource-variable/inter": "5.0.16",
-    "@headlessui/react": "^1.7.18",
+    "@headlessui/react": "1.7.17",
     "@heroicons/react": "2.0.17",
     "@lingui/core": "4.7.0",
     "@lingui/macro": "4.7.0",

--- a/packages/wagmi/package.json
+++ b/packages/wagmi/package.json
@@ -28,7 +28,7 @@
     "@ethersproject/constants": "^5.7.0",
     "@ethersproject/logger": "^5.7.0",
     "@ethersproject/providers": "^5.7.2",
-    "@headlessui/react": "^1.7.18",
+    "@headlessui/react": "1.7.17",
     "@heroicons/react": "2.0.17",
     "@lingui/core": "4.7.0",
     "@lingui/macro": "4.7.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -222,8 +222,8 @@ importers:
         specifier: ^5.7.0
         version: 5.7.0
       '@headlessui/react':
-        specifier: ^1.7.18
-        version: 1.7.18(react-dom@18.2.0)(react@18.2.0)
+        specifier: 1.7.17
+        version: 1.7.17(react-dom@18.2.0)(react@18.2.0)
       '@heroicons/react':
         specifier: 2.0.17
         version: 2.0.17(react@18.2.0)
@@ -479,8 +479,8 @@ importers:
         specifier: ^5.7.0
         version: 5.7.0
       '@headlessui/react':
-        specifier: ^1.7.18
-        version: 1.7.18(react-dom@18.2.0)(react@18.2.0)
+        specifier: 1.7.17
+        version: 1.7.17(react-dom@18.2.0)(react@18.2.0)
       '@heroicons/react':
         specifier: 2.0.17
         version: 2.0.17(react@18.2.0)
@@ -663,8 +663,8 @@ importers:
         specifier: ^5.7.2
         version: 5.7.2
       '@headlessui/react':
-        specifier: ^1.7.18
-        version: 1.7.18(react-dom@18.2.0)(react@18.2.0)
+        specifier: 1.7.17
+        version: 1.7.17(react-dom@18.2.0)(react@18.2.0)
       '@heroicons/react':
         specifier: 2.0.17
         version: 2.0.17(react@18.2.0)
@@ -820,8 +820,8 @@ importers:
         specifier: ^5.7.2
         version: 5.7.2
       '@headlessui/react':
-        specifier: ^1.7.18
-        version: 1.7.18(react-dom@18.2.0)(react@18.2.0)
+        specifier: 1.7.17
+        version: 1.7.17(react-dom@18.2.0)(react@18.2.0)
       '@heroicons/react':
         specifier: 2.0.17
         version: 2.0.17(react@18.2.0)
@@ -1087,8 +1087,8 @@ importers:
         specifier: ^5.7.0
         version: 5.7.0
       '@headlessui/react':
-        specifier: ^1.7.18
-        version: 1.7.18(react-dom@18.2.0)(react@18.2.0)
+        specifier: 1.7.17
+        version: 1.7.17(react-dom@18.2.0)(react@18.2.0)
       '@heroicons/react':
         specifier: 2.0.17
         version: 2.0.17(react@18.2.0)
@@ -1573,8 +1573,8 @@ importers:
   packages/parachains-impl/amplitude:
     dependencies:
       '@headlessui/react':
-        specifier: ^1.7.18
-        version: 1.7.18(react-dom@18.2.0)(react@18.2.0)
+        specifier: 1.7.17
+        version: 1.7.17(react-dom@18.2.0)(react@18.2.0)
       '@heroicons/react':
         specifier: ^2.0.17
         version: 2.0.17(react@18.2.0)
@@ -1664,8 +1664,8 @@ importers:
   packages/parachains-impl/bifrost:
     dependencies:
       '@headlessui/react':
-        specifier: ^1.7.18
-        version: 1.7.18(react-dom@18.2.0)(react@18.2.0)
+        specifier: 1.7.17
+        version: 1.7.17(react-dom@18.2.0)(react@18.2.0)
       '@heroicons/react':
         specifier: 2.0.17
         version: 2.0.17(react@18.2.0)
@@ -2167,8 +2167,8 @@ importers:
         specifier: 5.0.16
         version: 5.0.16
       '@headlessui/react':
-        specifier: ^1.7.18
-        version: 1.7.18(react-dom@18.2.0)(react@18.2.0)
+        specifier: 1.7.17
+        version: 1.7.17(react-dom@18.2.0)(react@18.2.0)
       '@heroicons/react':
         specifier: 2.0.17
         version: 2.0.17(react@18.2.0)
@@ -2285,8 +2285,8 @@ importers:
         specifier: ^5.7.2
         version: 5.7.2
       '@headlessui/react':
-        specifier: ^1.7.18
-        version: 1.7.18(react-dom@18.2.0)(react@18.2.0)
+        specifier: 1.7.17
+        version: 1.7.17(react-dom@18.2.0)(react@18.2.0)
       '@heroicons/react':
         specifier: 2.0.17
         version: 2.0.17(react@18.2.0)
@@ -6097,14 +6097,13 @@ packages:
     dependencies:
       '@hapi/hoek': 9.3.0
 
-  /@headlessui/react@1.7.18(react-dom@18.2.0)(react@18.2.0):
-    resolution: {integrity: sha512-4i5DOrzwN4qSgNsL4Si61VMkUcWbcSKueUV7sFhpHzQcSShdlHENE5+QBntMSRvHt8NyoFO2AGG8si9lq+w4zQ==}
+  /@headlessui/react@1.7.17(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-4am+tzvkqDSSgiwrsEpGWqgGo9dz8qU5M3znCkC4PgkpY4HcCZzEDEvozltGGGHIKl9jbXbZPSH5TWn4sWJdow==}
     engines: {node: '>=10'}
     peerDependencies:
       react: ^16 || ^17 || ^18
       react-dom: ^16 || ^17 || ^18
     dependencies:
-      '@tanstack/react-virtual': 3.0.1(react-dom@18.2.0)(react@18.2.0)
       client-only: 0.0.1
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
@@ -8684,11 +8683,25 @@ packages:
       '@polkadot/util': '*'
     dependencies:
       '@polkadot/keyring': 12.5.1(@polkadot/util-crypto@12.5.1)(@polkadot/util@12.5.1)
-      '@polkadot/ui-settings': 3.6.4(@polkadot/networks@12.6.2)(@polkadot/util@12.5.1)
+      '@polkadot/ui-settings': 3.6.4(@polkadot/networks@12.6.1)(@polkadot/util@12.5.1)
       '@polkadot/util': 12.5.1
       '@polkadot/util-crypto': 12.5.1(@polkadot/util@12.5.1)
       mkdirp: 3.0.1
       rxjs: 7.8.1
+      store: 2.0.12
+      tslib: 2.6.2
+    dev: false
+
+  /@polkadot/ui-settings@3.6.4(@polkadot/networks@12.6.1)(@polkadot/util@12.5.1):
+    resolution: {integrity: sha512-0vZPiMqGP9wv1SNBt0Snt6ScmrNHI2aqd9mixKs0pneDI0EO6ZndGanF3xgC51SCpS/N9qNh+VXckghmQMgaNQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@polkadot/networks': '*'
+      '@polkadot/util': '*'
+    dependencies:
+      '@polkadot/networks': 12.6.1
+      '@polkadot/util': 12.5.1
+      eventemitter3: 5.0.1
       store: 2.0.12
       tslib: 2.6.2
     dev: false
@@ -8702,20 +8715,6 @@ packages:
     dependencies:
       '@polkadot/networks': 12.6.1
       '@polkadot/util': 12.6.1
-      eventemitter3: 5.0.1
-      store: 2.0.12
-      tslib: 2.6.2
-    dev: false
-
-  /@polkadot/ui-settings@3.6.4(@polkadot/networks@12.6.2)(@polkadot/util@12.5.1):
-    resolution: {integrity: sha512-0vZPiMqGP9wv1SNBt0Snt6ScmrNHI2aqd9mixKs0pneDI0EO6ZndGanF3xgC51SCpS/N9qNh+VXckghmQMgaNQ==}
-    engines: {node: '>=18'}
-    peerDependencies:
-      '@polkadot/networks': '*'
-      '@polkadot/util': '*'
-    dependencies:
-      '@polkadot/networks': 12.6.2
-      '@polkadot/util': 12.5.1
       eventemitter3: 5.0.1
       store: 2.0.12
       tslib: 2.6.2
@@ -11154,24 +11153,9 @@ packages:
       react-dom: 18.2.0(react@18.2.0)
     dev: false
 
-  /@tanstack/react-virtual@3.0.1(react-dom@18.2.0)(react@18.2.0):
-    resolution: {integrity: sha512-IFOFuRUTaiM/yibty9qQ9BfycQnYXIDHGP2+cU+0LrFFGNhVxCXSQnaY6wkX8uJVteFEBjUondX0Hmpp7TNcag==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0
-      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
-    dependencies:
-      '@tanstack/virtual-core': 3.0.0
-      react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
-    dev: false
-
   /@tanstack/table-core@8.11.6:
     resolution: {integrity: sha512-69WEY1PaZROaGYUrseng4/4sMYnRGhDe1vM6888CnWekGz/wuCnvqwOoOuKGYivnaiI4BVmZq4WKWhvahyj3/g==}
     engines: {node: '>=12'}
-    dev: false
-
-  /@tanstack/virtual-core@3.0.0:
-    resolution: {integrity: sha512-SYXOBTjJb05rXa2vl55TTwO40A6wKu0R5i1qQwhJYNDIqaIGF7D0HsLw+pJAyi2OvntlEIVusx3xtbbgSUi6zg==}
     dev: false
 
   /@ts-morph/common@0.11.1:


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on improving the animation components in the UI package. 

### Detailed summary
- Refactored `useSlideInContext` to use a function declaration instead of an arrow function.
- Added the `show` prop to the `AppearOnMount` component.
- Reordered props in the `FromTop`, `FromLeft`, `FromRight`, and `FromBottom` components.
- Added `beforeEnter`, `beforeLeave`, `afterEnter`, and `afterLeave` props to the `FromTop`, `FromLeft`, `FromRight`, and `FromBottom` components.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->