### PR TITLE
Addition of missing pair addresses for Amplitude

### DIFF
--- a/packages/parachains-impl/amplitude/libs/constants/address.ts
+++ b/packages/parachains-impl/amplitude/libs/constants/address.ts
@@ -7,6 +7,21 @@ export const PAIR_ADDRESSES: Record<string, { address: string, account: string }
     address: '2124-2-1099511628544',
     account: '6jM63XCYUjHhdfXy9YMa2fKa9z4nqyJTb4DQxjm5mqsXBBQ5',
   },
+  // KSM-XLM
+  '2124-2-256-2124-2-512': {
+    address: '2124-2-2199040033536',
+    account: '6jM63XCYUjHhdfXy9YMZeyQcuvTA3qcMjFS4WxB86bWYG8Fh',
+  },
+  // USDT-USDC
+  '2124-2-257-2124-2-513': {
+    address: '2124-2-2203335066368',
+    account: '6jM63XCYUjHhdfXy9YMaMTNRKs1brVFqMDSZzcGSEb4f6jDc',
+  },
+  // AMPE-XLM
+  '2124-0-0-2124-2-512': {
+    address: '2124-2-2199023256320',
+    account: '6jM63XCYUjHhdfXy9YMbL6CZBGTqCURWv97c9Nu34eP5C6YD',
+  },
   // PEN-DOT
   '2094-0-0-2094-2-256': {
     address: '2094-2-1099511628544',

--- a/packages/token-lists/lists/amplitude.json
+++ b/packages/token-lists/lists/amplitude.json
@@ -30,7 +30,7 @@
       "assetType": 2,
       "assetIndex": 257,
       "symbol": "USDT",
-      "decimals": 12,
+      "decimals": 6,
       "name": "USDT Assethub"
     },
     {


### PR DESCRIPTION
This PR adds the addresses for the new pairs recently created in Amplitude.

<!-- start pr-codex -->

---

## PR-Codex overview
### Focus of the PR:
This PR focuses on updating the decimals value for the USDT token and adding new address and account values for different token pairs.

### Detailed summary:
- Updated the decimals value for the USDT token from 12 to 6.
- Added new address and account values for the KSM-XLM token pair.
- Added new address and account values for the USDT-USDC token pair.
- Added new address and account values for the AMPE-XLM token pair.
- Added new address value for the PEN-DOT token pair.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->