### PR TITLE
fix(polkadot): update the `useBalance` hook to use the `availableBalance`

### DIFF
--- a/packages/parachains-impl/amplitude/hooks/useBalance/useBalance.ts
+++ b/packages/parachains-impl/amplitude/hooks/useBalance/useBalance.ts
@@ -72,10 +72,10 @@ export const useBalances: UseBalances = ({
         result[validatedTokens[i].address] = Amount.fromRawAmount(validatedTokens[i], '0')
 
       if (isNativeCurrency(validatedTokens[i]))
-        result[validatedTokens[i].wrapped.address] = Amount.fromRawAmount(validatedTokens[i], nativeBalancesAll?.freeBalance.toString() || '0')
+        result[validatedTokens[i].wrapped.address] = Amount.fromRawAmount(validatedTokens[i], nativeBalancesAll?.availableBalance.toString() || '0')
     }
     return result
-  }, [balances, nativeBalancesAll?.freeBalance, validatedTokens])
+  }, [balances, nativeBalancesAll?.availableBalance, validatedTokens])
 
   return useMemo(() => ({
     data: balanceMap,

--- a/packages/parachains-impl/bifrost/components/Wallet/Profile/Default.tsx
+++ b/packages/parachains-impl/bifrost/components/Wallet/Profile/Default.tsx
@@ -34,7 +34,7 @@ export const Default: FC<DefaultProps> = ({
   const balancesAll = useNativeBalancesAll(chainId, account.address)
 
   const balance = useMemo(
-    () => Amount.fromRawAmount(Native.onChain(chainId), balancesAll ? balancesAll.freeBalance.toString() : '0'),
+    () => Amount.fromRawAmount(Native.onChain(chainId), balancesAll ? balancesAll.availableBalance.toString() : '0'),
     [balancesAll, chainId],
   )
 

--- a/packages/parachains-impl/bifrost/hooks/useBalance/useBalance.ts
+++ b/packages/parachains-impl/bifrost/hooks/useBalance/useBalance.ts
@@ -76,10 +76,10 @@ export const useBalances: UseBalances = ({
 
       // BNC
       if (isNativeCurrency(validatedTokens[i]))
-        result[validatedTokens[i].wrapped.address] = Amount.fromRawAmount(validatedTokens[i], nativeBalancesAll?.freeBalance.toString() || '0')
+        result[validatedTokens[i].wrapped.address] = Amount.fromRawAmount(validatedTokens[i], nativeBalancesAll?.availableBalance.toString() || '0')
     }
     return result
-  }, [balances, nativeBalancesAll?.freeBalance, validatedTokens])
+  }, [balances, nativeBalancesAll?.availableBalance, validatedTokens])
 
   return useMemo(() => ({
     data: balanceMap,


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
### Detailed summary
- Updated the `balance` calculation in `Default.tsx` and `useBalance.ts` files to use the `availableBalance` instead of `freeBalance`.
- Updated the `useBalance` hook in `useBalance.ts` to use the `availableBalance` instead of `freeBalance`.
- The changes ensure that the correct balance is used for calculations in the wallet profile and balance-related functionality.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->