### PR TITLE
feat(wagmi): show ensName by default

### DIFF
--- a/packages/wagmi/components/Wallet/Profile/Default.tsx
+++ b/packages/wagmi/components/Wallet/Profile/Default.tsx
@@ -65,7 +65,7 @@ export const Default: FC<DefaultProps> = ({ chainId, address, setView }) => {
               : (
                 <JazzIcon address={address} diameter={16} />
                 )}
-            {shortenAddress(address)}
+            {ensName || shortenAddress(address)}
           </Typography>
           <div className="flex gap-3">
             <CopyHelper hideIcon toCopy={address}>

--- a/packages/wagmi/components/Wallet/Profile/Profile.tsx
+++ b/packages/wagmi/components/Wallet/Profile/Profile.tsx
@@ -75,7 +75,7 @@ export const Profile: FC<ProfileProps> = ({ notifications, clearNotifications })
                   : (
                     <JazzIcon address={address} diameter={20} />
                     )}
-                {isSm ? shortenAddress(address) : ''}
+                {isSm ? ensName || shortenAddress(address) : ''}
                 <ChevronDownIcon
                   className={classNames(open ? 'rotate-180' : 'rotate-0', 'transition-transform')}
                   height={20}


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR enhances the Wallet Profile components by displaying ENS names alongside addresses when available.

### Detailed summary
- Added support to display ENS names in Wallet Profile components
- Updated rendering logic to show ENS name or address based on availability

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->