### PR TITLE
fix(wagmi): use 32 in bytes of the hex value

### DIFF
--- a/packages/wagmi/hooks/referrals/useCodeCheck.ts
+++ b/packages/wagmi/hooks/referrals/useCodeCheck.ts
@@ -31,7 +31,7 @@ export const useCodeCheck: UseCodeCheck = ({
     address: ReferralStorageContractAddresses[chainId && isEvmNetwork(chainId) ? chainId : -1] as Address,
     abi: referralStorage,
     functionName: 'codeOwners',
-    args: [stringToHex(code)],
+    args: [stringToHex(code, { size: 32 })],
   } as const), [chainId, code])
 
   const blockNumber = useBlockNumber(chainId)

--- a/packages/wagmi/hooks/referrals/useGenerateCodeReview.ts
+++ b/packages/wagmi/hooks/referrals/useGenerateCodeReview.ts
@@ -120,7 +120,7 @@ export const useGenerateCodeReview: UseGenerateCodeReview = ({
         calldata: encodeFunctionData({
           abi: referralStorage,
           functionName: 'registerCode',
-          args: [stringToHex(code)],
+          args: [stringToHex(code, { size: 32 })],
         }),
       }
       if (!isAddress(call.address))

--- a/packages/wagmi/hooks/referrals/useReferralInfo.ts
+++ b/packages/wagmi/hooks/referrals/useReferralInfo.ts
@@ -47,7 +47,7 @@ export const useReferralInfo: UseReferralInfo = ({
     return {
       data: (!code || code === zeroHash)
         ? undefined
-        : { code: hexToString(code), referrer },
+        : { code: hexToString(code, { size: 32 }), referrer },
       isLoading,
       isError,
     }

--- a/packages/wagmi/hooks/referrals/useSetCodeReview.ts
+++ b/packages/wagmi/hooks/referrals/useSetCodeReview.ts
@@ -120,7 +120,7 @@ export const useSetCodeReview: UseSetCodeReview = ({
         calldata: encodeFunctionData({
           abi: referralStorage,
           functionName: 'setReferralCodeByUser',
-          args: [stringToHex(code)],
+          args: [stringToHex(code, { size: 32 })],
         }),
       }
       if (!isAddress(call.address))


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates code related to generating, setting, and checking referral codes by adding a `{ size: 32 }` parameter to `stringToHex` calls for consistency.

### Detailed summary
- Added `{ size: 32 }` parameter to `stringToHex` calls in `useGenerateCodeReview.ts`, `useReferralInfo.ts`, `useSetCodeReview.ts`, and `useCodeCheck.ts` for referral code handling consistency.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->