### PR TITLE
fix(swap): default token1 on moonriver

### DIFF
--- a/apps/swap/pages/index.tsx
+++ b/apps/swap/pages/index.tsx
@@ -2,7 +2,7 @@ import { ChevronDownIcon } from '@heroicons/react/20/solid'
 import { TradeType } from '@zenlink-interface/amm'
 import { ParachainId } from '@zenlink-interface/chain'
 import type { Type } from '@zenlink-interface/currency'
-import { DOT, KSM, Native, USDC, USDT, tryParseAmount } from '@zenlink-interface/currency'
+import { DOT, FRAX, KSM, Native, USDC, USDT, tryParseAmount } from '@zenlink-interface/currency'
 import { useIsMounted, usePrevious } from '@zenlink-interface/hooks'
 import { Button, Dots, Tab, Widget } from '@zenlink-interface/ui'
 import { WrapType } from '@zenlink-interface/wagmi'
@@ -46,14 +46,16 @@ export const getServerSideProps: GetServerSideProps = async ({ query, res }) => 
 const SWAP_DEFAULT_SLIPPAGE = new Percent(50, 10_000) // 0.50%
 
 function getDefaultToken1(chainId: number): Type | undefined {
+  if (chainId === ParachainId.MOONRIVER && chainId in FRAX)
+    return FRAX[chainId]
   if (chainId in USDC)
-    return USDC[chainId as keyof typeof USDC]
+    return USDC[chainId]
   if (chainId in USDT)
-    return USDT[chainId as keyof typeof USDT]
+    return USDT[chainId]
   if (chainId in DOT)
-    return DOT[chainId as keyof typeof DOT]
+    return DOT[chainId]
   if (chainId in KSM)
-    return KSM[chainId as keyof typeof KSM]
+    return KSM[chainId]
   return undefined
 }
 

--- a/apps/swap/pages/index.tsx
+++ b/apps/swap/pages/index.tsx
@@ -43,7 +43,7 @@ export const getServerSideProps: GetServerSideProps = async ({ query, res }) => 
   }
 }
 
-const SWAP_DEFAULT_SLIPPAGE = new Percent(50, 10_000) // 0.50%
+const SWAP_DEFAULT_SLIPPAGE = new Percent(100, 10_000) // 1.00%
 
 function getDefaultToken1(chainId: number): Type | undefined {
   if (chainId === ParachainId.MOONRIVER && chainId in FRAX)


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates default slippage to 1.00% and adds support for the FRAX currency on Moonriver chain.

### Detailed summary
- Updated default slippage to 1.00%
- Added support for FRAX currency on Moonriver chain

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->