### PR TITLE
Update parachains.json

### DIFF
--- a/packages/chain/parachains.json
+++ b/packages/chain/parachains.json
@@ -96,7 +96,7 @@
     "explorers": [
       {
         "name": "subscan",
-        "url": "https://polkadot.subscan.io/parachain/2094",
+        "url": "https://pendulum.subscan.io/",
         "standard": "none"
       }
     ]


### PR DESCRIPTION
Updated the subscan link for Pendulum

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the URL for the `subscan` parachain from `https://polkadot.subscan.io/parachain/2094` to `https://pendulum.subscan.io/`.

### Detailed summary
- Updated `subscan` parachain URL to `https://pendulum.subscan.io/`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->