### PR TITLE
fix: remove price jobs from uni

### DIFF
--- a/apis/token-price/config.ts
+++ b/apis/token-price/config.ts
@@ -13,8 +13,8 @@ export const MARKET_SUPPORTED_CHAINS = [
 ]
 
 export const UNI_SUPPORTED_CHAINS = [
-  ParachainId.ARBITRUM_ONE,
-  ParachainId.BASE,
+  // ParachainId.ARBITRUM_ONE,
+  // ParachainId.BASE,
 ]
 
 export const LIFI_SUPPORTED_CHAINS = [


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR removes two ParachainId constants from `UNI_SUPPORTED_CHAINS` in `apis/token-price/config.ts`.

### Detailed summary
- Removed `ParachainId.ARBITRUM_ONE` from `UNI_SUPPORTED_CHAINS`
- Removed `ParachainId.BASE` from `UNI_SUPPORTED_CHAINS`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->