### PR TITLE
Update bifrost-polkadot.json

### DIFF
--- a/packages/token-lists/lists/bifrost-polkadot.json
+++ b/packages/token-lists/lists/bifrost-polkadot.json
@@ -1,5 +1,5 @@
 {
-  "name": "bifrost kusama",
+  "name": "bifrost polkadot",
   "timestamp": "2022-12-21T12:02:57.229Z",
   "tokens": [
     {


### PR DESCRIPTION
- **name** is wrong. It was "bifrost kusama" but it should be "bifrost polkadot" since the file is handling bifrost polkadot assets

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the `name` field in the `bifrost-polkadot.json` file to correct the name from "bifrost kusama" to "bifrost polkadot".

### Detailed summary
- Changed the `name` from "bifrost kusama" to "bifrost polkadot" in `bifrost-polkadot.json`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->